### PR TITLE
Prioritize recent tower entries in chart display

### DIFF
--- a/DJDX/Views/Tower/TowerView.swift
+++ b/DJDX/Views/Tower/TowerView.swift
@@ -22,7 +22,12 @@ struct TowerView: View {
     @AppStorage(wrappedValue: .totals, "TowerView.DisplayMode") var chartMode: TowerChartMode
 
     var chartEntries: [IIDXTowerEntry] {
-        Array(towerEntries.prefix(5)).reversed()
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: .now)!
+        let recentEntries = towerEntries.prefix(while: { $0.playDate >= thirtyDaysAgo })
+        if recentEntries.count >= 5 {
+            return Array(recentEntries).reversed()
+        }
+        return Array(towerEntries.prefix(5)).reversed()
     }
 
     var totalKeyCount: Int {


### PR DESCRIPTION
## Summary
Updated the tower chart to prioritize displaying entries from the last 30 days when sufficient recent data is available, while maintaining backward compatibility with the previous behavior.

## Key Changes
- Modified `chartEntries` computed property in `TowerView` to filter tower entries by a 30-day window
- Implemented logic to prefer recent entries: if 5 or more entries exist within the last 30 days, display those; otherwise fall back to the 5 most recent entries regardless of date
- Entries are still reversed for proper chart display order

## Implementation Details
- Uses `Calendar.current.date(byAdding:to:)` to calculate the 30-day cutoff date
- Leverages `prefix(while:)` to efficiently filter entries by `playDate`
- Maintains the existing behavior as a fallback when insufficient recent data exists

https://claude.ai/code/session_016aUR2BF2baestLXKptBHBD