### PR TITLE
Bump version to 33.2.3 and convert filter menu to sheet

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.2;
+				MARKETING_VERSION = 33.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.2;
+				MARKETING_VERSION = 33.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.2;
+				MARKETING_VERSION = 33.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.2;
+				MARKETING_VERSION = 33.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DJDX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DJDX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "0c08856385fe24f7b76d8c51842d78a196e8e817",
-        "version" : "0.15.5"
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {

--- a/DJDX/Actors/DataFetcher.swift
+++ b/DJDX/Actors/DataFetcher.swift
@@ -146,25 +146,11 @@ actor DataFetcher {
                 $0.playType == filters.playType
             })
 
-            if !filters.version.isEmpty {
-                filteredSongRecords.removeAll { $0.version != filters.version }
+            if !filters.versions.isEmpty {
+                filteredSongRecords.removeAll { !filters.versions.contains($0.version) }
             }
 
             if filters.onlyPlayDataWithScores {
-                if filters.level != .all,
-                   let keyPath = scoreKeyPath(for: filters.level) {
-                        filteredSongRecords.removeAll { songRecord in
-                            songRecord[keyPath: keyPath].score == 0
-                        }
-                }
-                if filters.difficulty != .all {
-                    filteredSongRecords.removeAll { songRecord in
-                        if let score = songRecord.score(for: filters.difficulty) {
-                            return score.score == 0
-                        }
-                        return false
-                    }
-                }
                 filteredSongRecords.removeAll { songRecord in
                     songRecord.beginnerScore.score == 0 &&
                     songRecord.normalScore.score == 0 &&
@@ -174,66 +160,37 @@ actor DataFetcher {
                 }
             }
 
-            filteredSongRecords.removeAll { songRecord in
+            let hasLevelFilter = !filters.levels.isEmpty
+            let hasDifficultyFilter = !filters.difficulties.isEmpty
+            let hasClearTypeFilter = !filters.clearTypes.isEmpty
+            let hasDJLevelFilter = !filters.djLevels.isEmpty
+            let difficultyRawValues = Set(filters.difficulties.map(\.rawValue))
+            let clearTypeRawValues = Set(filters.clearTypes.map(\.rawValue))
+            let djLevelRawValues = Set(filters.djLevels.map(\.rawValue))
 
-                if filters.difficulty != .all, songRecord.score(for: filters.difficulty) == nil {
-                    return true
-                }
-
-                if filters.level != .all {
-                    if songRecord.score(for: filters.level) == nil {
-                        return true
-                    } else {
-                        if filters.difficulty != .all,
-                           songRecord.score(for: filters.level)?.difficulty != filters.difficulty.rawValue {
-                            return true
+            if hasLevelFilter || hasDifficultyFilter || hasClearTypeFilter || hasDJLevelFilter {
+                filteredSongRecords.removeAll { songRecord in
+                    let scores = songRecord.scores()
+                    let hasMatchingScore = scores.contains { score in
+                        if hasLevelFilter, !filters.levels.contains(score.level) {
+                            return false
                         }
-                    }
-                }
-
-                if filters.clearType != .all {
-                    let isDifficultyFilterActive = filters.difficulty != .all
-                    let isLevelFilterActive = filters.level != .all
-                    if isDifficultyFilterActive && !isLevelFilterActive,
-                       songRecord.score(for: filters.difficulty)?.clearType != filters.clearType.rawValue {
-                        return true
-                    } else if isDifficultyFilterActive && isLevelFilterActive,
-                              songRecord.score(for: filters.level)?.clearType != filters.clearType.rawValue {
-                        return true
-                    } else if isDifficultyFilterActive && isLevelFilterActive,
-                              songRecord.score(for: filters.difficulty)?.level ==
-                                songRecord.score(for: filters.level)?.level,
-                              songRecord.score(for: filters.difficulty)?.clearType != filters.clearType.rawValue {
-                        return true
-                    } else {
-                        if !songRecord.scores().contains(where: { $0.clearType == filters.clearType.rawValue }) {
-                            return true
+                        if hasDifficultyFilter, !difficultyRawValues.contains(score.difficulty) {
+                            return false
                         }
-                    }
-                }
-
-                if filters.djLevel != .all {
-                    let isDifficultyFilterActive = filters.difficulty != .all
-                    let isLevelFilterActive = filters.level != .all
-                    if isDifficultyFilterActive && !isLevelFilterActive,
-                       songRecord.score(for: filters.difficulty)?.djLevel != filters.djLevel.rawValue {
-                        return true
-                    } else if isDifficultyFilterActive && isLevelFilterActive,
-                              songRecord.score(for: filters.level)?.djLevel != filters.djLevel.rawValue {
-                        return true
-                    } else if isDifficultyFilterActive && isLevelFilterActive,
-                              songRecord.score(for: filters.difficulty)?.level ==
-                                songRecord.score(for: filters.level)?.level,
-                              songRecord.score(for: filters.difficulty)?.djLevel != filters.djLevel.rawValue {
-                        return true
-                    } else {
-                        if !songRecord.scores().contains(where: { $0.djLevel == filters.djLevel.rawValue }) {
-                            return true
+                        if hasClearTypeFilter, !clearTypeRawValues.contains(score.clearType) {
+                            return false
                         }
+                        if hasDJLevelFilter, !djLevelRawValues.contains(score.djLevel) {
+                            return false
+                        }
+                        if filters.onlyPlayDataWithScores, score.score == 0 {
+                            return false
+                        }
+                        return true
                     }
+                    return !hasMatchingScore
                 }
-
-                return false
             }
 
             songRecords = filteredSongRecords
@@ -249,14 +206,16 @@ actor DataFetcher {
             var songLevelScores: [IIDXSongRecord: IIDXLevelScore] = [:]
 
             if sortOptions.mode != .title && sortOptions.mode != .lastPlayDate {
-                if let level = filters?.level,
-                   level != .all,
-                    let keyPath = scoreKeyPath(for: level) {
+                if let levels = filters?.levels,
+                   levels.count == 1,
+                   let level = levels.first,
+                   let keyPath = scoreKeyPath(for: level) {
                     songLevelScores = sortedSongRecords.reduce(into: [:], { partialResult, songRecord in
                         partialResult[songRecord] = songRecord[keyPath: keyPath]
                     })
-                } else if let difficulty = filters?.difficulty,
-                          difficulty != .all {
+                } else if let difficulties = filters?.difficulties,
+                          difficulties.count == 1,
+                          let difficulty = difficulties.first {
                     songLevelScores = sortedSongRecords.reduce(into: [:], { partialResult, songRecord in
                         partialResult[songRecord] = songRecord.score(for: difficulty)
                     })

--- a/DJDX/Actors/DataFetcher.swift
+++ b/DJDX/Actors/DataFetcher.swift
@@ -224,6 +224,13 @@ actor DataFetcher {
 
             let isAscending = sortOptions.order == .ascending
 
+            if songLevelScores.isEmpty {
+                // When no single level/difficulty is selected, sort by title as a base order.
+                // Per-level sorting is handled at the view layer.
+                sortedSongRecords.sort { lhs, rhs in
+                    isAscending ? lhs.title < rhs.title : lhs.title > rhs.title
+                }
+            } else {
             switch sortOptions.mode {
             case .title:
                 sortedSongRecords.sort { lhs, rhs in
@@ -340,6 +347,7 @@ actor DataFetcher {
                         : lhs.lastPlayDate > rhs.lastPlayDate
                 }
             }
+            } // else songLevelScores.isEmpty
 
             songRecords = sortedSongRecords
         } else {

--- a/DJDX/Enums/AnalyticsPerLevelCategory.swift
+++ b/DJDX/Enums/AnalyticsPerLevelCategory.swift
@@ -18,8 +18,8 @@ enum AnalyticsPerLevelCategory: String, Codable, CaseIterable, Identifiable {
 
     var titleKey: String {
         switch self {
-        case .clearRate: return "Analytics.PerLevel.ClearRate"
-        case .clearRateTrend: return "Analytics.PerLevel.ClearRateTrend"
+        case .clearRate: return "Shared.IIDX.ClearType"
+        case .clearRateTrend: return "Analytics.PerLevel.ClearTypeTrend"
         case .djLevel: return "Shared.IIDX.DJLevel"
         case .djLevelTrend: return "Analytics.PerLevel.DJLevelTrend"
         }

--- a/DJDX/Enums/SortMode.swift
+++ b/DJDX/Enums/SortMode.swift
@@ -38,6 +38,11 @@ enum SortMode: String, CaseIterable, Codable {
         .lastPlayDate
     ]
 
+    static let defaultModes: [SortMode] = [
+        .title,
+        .lastPlayDate
+    ]
+
     private var extraRawValues: [String] {
         switch self {
         case .title: return ["タイトル", "Shared.Sort.Title"]

--- a/DJDX/Enums/ViewPath.swift
+++ b/DJDX/Enums/ViewPath.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ViewPath: Hashable {
-    case scoreViewer(songRecord: IIDXSongRecord)
+    case scoreViewer(songRecord: IIDXSongRecord, initialLevel: IIDXLevel = .all)
     case scoreHistory(songTitle: String,
                       level: IIDXLevel,
                       noteCount: Int?)

--- a/DJDX/Extensions/Set+RawRepresentable.swift
+++ b/DJDX/Extensions/Set+RawRepresentable.swift
@@ -1,0 +1,24 @@
+//
+//  Set+RawRepresentable.swift
+//  DJDX
+//
+//  Created on 2026/04/01.
+//
+
+import Foundation
+
+extension Set: @retroactive RawRepresentable where Element: Codable {
+    public init?(rawValue: String) {
+        guard let data = rawValue.data(using: .utf8),
+              let result = try? JSONDecoder().decode(Set<Element>.self, from: data)
+        else { return nil }
+        self = result
+    }
+
+    public var rawValue: String {
+        guard let data = try? JSONEncoder().encode(self),
+              let result = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return result
+    }
+}

--- a/DJDX/Structs/FilterOptions.swift
+++ b/DJDX/Structs/FilterOptions.swift
@@ -8,19 +8,9 @@
 struct FilterOptions: Equatable {
     var playType: IIDXPlayType
     var onlyPlayDataWithScores: Bool
-    var level: IIDXLevel
-    var difficulty: IIDXDifficulty
-    var clearType: IIDXClearType
-    var djLevel: IIDXDJLevel
-    var version: String
-
-    static func == (lhs: FilterOptions, rhs: FilterOptions) -> Bool {
-        lhs.playType == rhs.playType &&
-        lhs.onlyPlayDataWithScores == rhs.onlyPlayDataWithScores &&
-        lhs.level == rhs.level &&
-        lhs.difficulty == rhs.difficulty &&
-        lhs.clearType == rhs.clearType &&
-        lhs.djLevel == rhs.djLevel &&
-        lhs.version == rhs.version
-    }
+    var levels: Set<IIDXLevel>
+    var difficulties: Set<IIDXDifficulty>
+    var clearTypes: Set<IIDXClearType>
+    var djLevels: Set<IIDXDJLevel>
+    var versions: Set<String>
 }

--- a/DJDX/Structs/Radar/RadarData.swift
+++ b/DJDX/Structs/Radar/RadarData.swift
@@ -77,7 +77,9 @@ struct RadarData {
 
     func color() -> Color {
         let sum = self.sum()
-        if sum > 600.0 {
+        if sum > 800.0 {
+            return .green
+        } else if sum > 600.0 {
             return .purple
         } else if sum > 400.0 {
             return .red

--- a/DJDX/Structs/Radar/RadarData.swift
+++ b/DJDX/Structs/Radar/RadarData.swift
@@ -75,9 +75,9 @@ struct RadarData {
         return [self.notes, self.peak, self.scratch, self.soflan, self.charge, self.chord].reduce(0, +)
     }
 
-    func color() -> Color {
+    func color(isPlayerRadar: Bool = false) -> Color {
         let sum = self.sum()
-        if sum > 800.0 {
+        if isPlayerRadar && sum > 800.0 {
             return .green
         } else if sum > 600.0 {
             return .purple

--- a/DJDX/Views/Analytics/AnalyticsSettingsSheet.swift
+++ b/DJDX/Views/Analytics/AnalyticsSettingsSheet.swift
@@ -98,6 +98,7 @@ struct AnalyticsSettingsSheet: View {
                     }
                 }
             }
+            .listSectionSpacing(.compact)
             .navigationTitle("Analytics.Settings.Title")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/DJDX/Views/More/MoreNotesRadarView.swift
+++ b/DJDX/Views/More/MoreNotesRadarView.swift
@@ -43,7 +43,7 @@ struct MoreNotesRadarView: View {
             .padding(.horizontal)
 
             if let radarData = currentRadarData {
-                RadarChartView(radarData)
+                RadarChartView(radarData, isPlayerRadar: true)
                     .frame(height: 200.0)
                     .padding()
                     .animation(.smooth, value: selectedPlayType)

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -24,24 +24,24 @@ struct ScoreRow: View {
     var songRecord: IIDXSongRecord
     @State var scoreRate: Float?
 
-    @Binding var levelToShow: IIDXLevel
-    @Binding var difficultyToShow: IIDXDifficulty
+    var levelToShow: IIDXLevel
+    var difficultyToShow: IIDXDifficulty
 
     var score: IIDXLevelScore?
 
     init(namespace: Namespace.ID,
          songRecord: IIDXSongRecord,
          scoreRate: Float?,
-         levelToShow: Binding<IIDXLevel>,
-         difficultyToShow: Binding<IIDXDifficulty>) {
+         levelToShow: IIDXLevel,
+         difficultyToShow: IIDXDifficulty) {
         self.namespace = namespace
         self.songRecord = songRecord
         self.scoreRate = scoreRate
-        self._levelToShow = levelToShow
-        self._difficultyToShow = difficultyToShow
+        self.levelToShow = levelToShow
+        self.difficultyToShow = difficultyToShow
         let scores: [IIDXLevelScore?] = [
-            songRecord.score(for: levelToShow.wrappedValue),
-            songRecord.score(for: difficultyToShow.wrappedValue)
+            songRecord.score(for: levelToShow),
+            songRecord.score(for: difficultyToShow)
         ]
         self.score = (scores.first(where: { $0 != nil }) ?? nil) ?? nil
     }

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -26,6 +26,7 @@ struct ScoreRow: View {
 
     var levelToShow: IIDXLevel
     var difficultyToShow: IIDXDifficulty
+    var levelsToShow: Set<IIDXLevel>
 
     var score: IIDXLevelScore?
 
@@ -33,12 +34,14 @@ struct ScoreRow: View {
          songRecord: IIDXSongRecord,
          scoreRate: Float?,
          levelToShow: IIDXLevel,
-         difficultyToShow: IIDXDifficulty) {
+         difficultyToShow: IIDXDifficulty,
+         levelsToShow: Set<IIDXLevel> = []) {
         self.namespace = namespace
         self.songRecord = songRecord
         self.scoreRate = scoreRate
         self.levelToShow = levelToShow
         self.difficultyToShow = difficultyToShow
+        self.levelsToShow = levelsToShow
         let scores: [IIDXLevelScore?] = [
             songRecord.score(for: levelToShow),
             songRecord.score(for: difficultyToShow)
@@ -181,7 +184,8 @@ struct ScoreRow: View {
             if isLevelVisible && levelToShow == .all && difficultyToShow == .all {
                 HStack(alignment: .center, spacing: 8.0) {
                     Spacer(minLength: 0.0)
-                    IIDXLevelShowcase(songRecord: songRecord)
+                    IIDXLevelShowcase(songRecord: songRecord,
+                                      visibleLevels: levelsToShow)
                 }
                 .padding([.bottom], 8.0)
             }

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -48,9 +48,9 @@ struct ScoreRow: View {
                 case "CLEAR": Color.cyan
                 case "EASY CLEAR": Color.green
                 case "ASSIST CLEAR": Color.purple
-                case "HARD CLEAR": Color.pink
+                case "HARD CLEAR": Color.red
                 case "EX HARD CLEAR": Color.yellow
-                case "FAILED": Color.red
+                case "FAILED": Color.gray
                 default: Color.clear
                 }
             }

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -22,174 +22,134 @@ struct ScoreRow: View {
     var namespace: Namespace.ID
 
     var songRecord: IIDXSongRecord
+    var level: IIDXLevel
+    var score: IIDXLevelScore
     @State var scoreRate: Float?
 
-    var levelToShow: IIDXLevel
-    var difficultyToShow: IIDXDifficulty
-    var levelsToShow: Set<IIDXLevel>
-
-    var score: IIDXLevelScore?
-
-    init(namespace: Namespace.ID,
-         songRecord: IIDXSongRecord,
-         scoreRate: Float?,
-         levelToShow: IIDXLevel,
-         difficultyToShow: IIDXDifficulty,
-         levelsToShow: Set<IIDXLevel> = []) {
-        self.namespace = namespace
-        self.songRecord = songRecord
-        self.scoreRate = scoreRate
-        self.levelToShow = levelToShow
-        self.difficultyToShow = difficultyToShow
-        self.levelsToShow = levelsToShow
-        let scores: [IIDXLevelScore?] = [
-            songRecord.score(for: levelToShow),
-            songRecord.score(for: difficultyToShow)
-        ]
-        self.score = (scores.first(where: { $0 != nil }) ?? nil) ?? nil
-    }
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 4.0) {
-            HStack(alignment: .center, spacing: 8.0) {
-                // Leading Clear Lamp
-                VStack {
-                    if let score = score {
-                        switch score.clearType {
-                        case "FULLCOMBO CLEAR":
-                            LinearGradient(
-                                gradient: Gradient(colors: [
-                                    Color.red,
-                                    Color.orange,
-                                    Color.yellow,
-                                    Color.green,
-                                    Color.blue,
-                                    Color.indigo,
-                                    Color.purple
-                                ]),
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        case "CLEAR": Color.cyan
-                        case "EASY CLEAR": Color.green
-                        case "ASSIST CLEAR": Color.purple
-                        case "HARD CLEAR": Color.pink
-                        case "EX HARD CLEAR": Color.yellow
-                        case "FAILED": Color.red
-                        default: Color.clear
-                        }
-                    } else {
-                        Color.clear
-                    }
+        HStack(alignment: .center, spacing: 8.0) {
+            // Leading Clear Lamp
+            VStack {
+                switch score.clearType {
+                case "FULLCOMBO CLEAR":
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            Color.red,
+                            Color.orange,
+                            Color.yellow,
+                            Color.green,
+                            Color.blue,
+                            Color.indigo,
+                            Color.purple
+                        ]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                case "CLEAR": Color.cyan
+                case "EASY CLEAR": Color.green
+                case "ASSIST CLEAR": Color.purple
+                case "HARD CLEAR": Color.pink
+                case "EX HARD CLEAR": Color.yellow
+                case "FAILED": Color.red
+                default: Color.clear
                 }
-                .frame(width: 12.0)
-                .frame(maxHeight: .infinity)
-                .conditionalShadow(.black.opacity(0.2), radius: 1.0, x: 2.0)
+            }
+            .frame(width: 12.0)
+            .frame(maxHeight: .infinity)
+            .conditionalShadow(.black.opacity(0.2), radius: 1.0, x: 2.0)
 
-                HStack(alignment: .center, spacing: 0.0) {
-                    // Song Info
-                    VStack(alignment: .leading, spacing: 2.0) {
-                        if isGenreVisible {
-                            Text(songRecord.genre)
-                                .foregroundStyle(.secondary)
-                                .font(.caption2)
-                                .fontWidth(.condensed)
-                        }
-                        Text(songRecord.title)
-                            .bold()
+            HStack(alignment: .center, spacing: 0.0) {
+                // Song Info
+                VStack(alignment: .leading, spacing: 2.0) {
+                    if isGenreVisible {
+                        Text(songRecord.genre)
+                            .foregroundStyle(.secondary)
+                            .font(.caption2)
                             .fontWidth(.condensed)
-                        if isArtistVisible {
-                            Text(songRecord.artist)
-                                .font(.caption)
-                                .fontWidth(.condensed)
-                        }
-                        // Metadata Row
-                        if isDJLevelVisible || isScoreRateVisible || isScoreVisible || isLastPlayDateVisible {
-                            HStack(alignment: .center, spacing: 6.0) {
-                                if let score = score,
-                                   score.score != 0 {
-                                    Group {
-                                        if isDJLevelVisible {
-                                            Text(score.djLevel)
-                                                .foregroundStyle(
-                                                    IIDXDJLevel.style(for: score.djLevel, colorScheme: colorScheme)
-                                                )
-                                                .fontWidth(.expanded)
-                                                .fontWeight(.black)
-                                        }
-                                        if isScoreRateVisible, let scoreRate {
-                                            if isDJLevelVisible {
-                                                Divider()
-                                                    .frame(maxHeight: 14.0)
-                                            }
-                                            Text(scoreRate, format: .percent.precision(.fractionLength(1)))
-                                                .foregroundStyle(LinearGradient(
-                                                    colors: [.primary.opacity(0.55), .primary.opacity(0.3)],
-                                                    startPoint: .top,
-                                                    endPoint: .bottom
-                                                ))
-                                                .fontWidth(.expanded)
-                                                .fontWeight(.black)
-                                        }
-                                        if isScoreVisible {
-                                            if isDJLevelVisible || isScoreRateVisible {
-                                                Divider()
-                                                    .frame(maxHeight: 14.0)
-                                            }
-                                            Text(String(score.score))
-                                                .foregroundStyle(LinearGradient(colors: [.cyan, .blue],
-                                                                                startPoint: .top,
-                                                                                endPoint: .bottom))
-                                                .fontWidth(.expanded)
-                                                .fontWeight(.heavy)
-                                        }
+                    }
+                    Text(songRecord.title)
+                        .bold()
+                        .fontWidth(.condensed)
+                    if isArtistVisible {
+                        Text(songRecord.artist)
+                            .font(.caption)
+                            .fontWidth(.condensed)
+                    }
+                    // Metadata Row
+                    if isDJLevelVisible || isScoreRateVisible || isScoreVisible || isLastPlayDateVisible {
+                        HStack(alignment: .center, spacing: 6.0) {
+                            if score.score != 0 {
+                                Group {
+                                    if isDJLevelVisible {
+                                        Text(score.djLevel)
+                                            .foregroundStyle(
+                                                IIDXDJLevel.style(for: score.djLevel, colorScheme: colorScheme)
+                                            )
+                                            .fontWidth(.expanded)
+                                            .fontWeight(.black)
                                     }
-                                    .font(.caption)
-                                    if isLastPlayDateVisible {
-                                        if isDJLevelVisible || isScoreRateVisible || isScoreVisible {
+                                    if isScoreRateVisible, let scoreRate {
+                                        if isDJLevelVisible {
                                             Divider()
                                                 .frame(maxHeight: 14.0)
                                         }
-                                        Text(RelativeDateTimeFormatter().localizedString(
-                                            for: songRecord.lastPlayDate,
-                                            relativeTo: .now
-                                        ))
-                                        .foregroundStyle(.secondary)
-                                        .fontWidth(.condensed)
+                                        Text(scoreRate, format: .percent.precision(.fractionLength(1)))
+                                            .foregroundStyle(LinearGradient(
+                                                colors: [.primary.opacity(0.55), .primary.opacity(0.3)],
+                                                startPoint: .top,
+                                                endPoint: .bottom
+                                            ))
+                                            .fontWidth(.expanded)
+                                            .fontWeight(.black)
+                                    }
+                                    if isScoreVisible {
+                                        if isDJLevelVisible || isScoreRateVisible {
+                                            Divider()
+                                                .frame(maxHeight: 14.0)
+                                        }
+                                        Text(String(score.score))
+                                            .foregroundStyle(LinearGradient(colors: [.cyan, .blue],
+                                                                            startPoint: .top,
+                                                                            endPoint: .bottom))
+                                            .fontWidth(.expanded)
+                                            .fontWeight(.heavy)
                                     }
                                 }
+                                .font(.caption)
+                                if isLastPlayDateVisible {
+                                    if isDJLevelVisible || isScoreRateVisible || isScoreVisible {
+                                        Divider()
+                                            .frame(maxHeight: 14.0)
+                                    }
+                                    Text(RelativeDateTimeFormatter().localizedString(
+                                        for: songRecord.lastPlayDate,
+                                        relativeTo: .now
+                                    ))
+                                    .foregroundStyle(.secondary)
+                                    .fontWidth(.condensed)
+                                }
                             }
-                            .offset(y: 1.0)
-                            .font(.caption)
                         }
+                        .offset(y: 1.0)
+                        .font(.caption)
                     }
-                    Spacer(minLength: 0.0)
                 }
-                .padding([.top, .bottom], 8.0)
-                .automaticMatchedTransitionSource(id: songRecord.title, in: namespace)
-
-                // Level
-                if isLevelVisible, let score = score {
-                    IIDXLevelLabel(levelType: score.level, songRecord: songRecord)
-                        .padding([.top, .bottom], 6.0)
-                        .frame(width: 78.0, alignment: .center)
-                        .background(.thinMaterial)
-                        .clipShape(.rect(cornerRadius: 6.0))
-                        .padding([.top, .bottom], 8.0)
-                }
+                Spacer(minLength: 0.0)
             }
-            .frame(maxWidth: .infinity)
+            .padding([.top, .bottom], 8.0)
+            .automaticMatchedTransitionSource(id: songRecord.title, in: namespace)
 
-            // Levels
-            if isLevelVisible && levelToShow == .all && difficultyToShow == .all {
-                HStack(alignment: .center, spacing: 8.0) {
-                    Spacer(minLength: 0.0)
-                    IIDXLevelShowcase(songRecord: songRecord,
-                                      visibleLevels: levelsToShow)
-                }
-                .padding([.bottom], 8.0)
+            // Level
+            if isLevelVisible {
+                IIDXLevelLabel(levelType: level, score: score)
+                    .padding([.top, .bottom], 6.0)
+                    .frame(width: 78.0, alignment: .center)
+                    .background(.thinMaterial)
+                    .clipShape(.rect(cornerRadius: 6.0))
+                    .padding([.top, .bottom], 8.0)
             }
         }
+        .frame(maxWidth: .infinity)
         .padding([.trailing], 20.0)
     }
 }

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -48,9 +48,9 @@ struct ScoreRow: View {
                 case "CLEAR": Color.cyan
                 case "EASY CLEAR": Color.green
                 case "ASSIST CLEAR": Color.purple
-                case "HARD CLEAR": Color.red
+                case "HARD CLEAR": colorScheme == .dark ? Color.white : Color.gray
                 case "EX HARD CLEAR": Color.yellow
-                case "FAILED": Color.gray
+                case "FAILED": Color.red
                 default: Color.clear
                 }
             }

--- a/DJDX/Views/Scores/ScoreRow.swift
+++ b/DJDX/Views/Scores/ScoreRow.swift
@@ -49,7 +49,7 @@ struct ScoreRow: View {
                 case "EASY CLEAR": Color.green
                 case "ASSIST CLEAR": Color.purple
                 case "HARD CLEAR": colorScheme == .dark ? Color.white : Color.gray
-                case "EX HARD CLEAR": Color.yellow
+                case "EX HARD CLEAR": Color.orange
                 case "FAILED": Color.red
                 default: Color.clear
                 }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -130,13 +130,13 @@ struct ScoreFilterSheet: View {
                         label: { Text("LEVEL \($0.rawValue)") }
                     )
                     multiSelectMenu(
-                        "Shared.IIDX.ClearType",
+                        .sharedIIDXClearType,
                         items: IIDXClearType.sorted,
                         selection: $clearTypesToShow,
                         label: { Text(LocalizedStringKey($0.rawValue)) }
                     )
                     multiSelectMenu(
-                        "Shared.IIDX.DJLevel",
+                        .sharedIIDXDJLevel,
                         items: IIDXDJLevel.sorted.reversed(),
                         selection: $djLevelsToShow,
                         label: { Text(verbatim: $0.rawValue) }
@@ -194,7 +194,7 @@ struct ScoreFilterSheet: View {
     // MARK: Multi-Select Menu (Hashable items)
 
     private func multiSelectMenu<Item: Hashable>(
-        _ title: LocalizedStringKey,
+        _ title: LocalizedStringResource,
         items: [Item],
         selection: Binding<Set<Item>>,
         label: @escaping (Item) -> Text
@@ -236,7 +236,7 @@ struct ScoreFilterSheet: View {
     // MARK: Multi-Select Menu (custom ID key path for non-Hashable display)
 
     private func multiSelectMenu<Item: Hashable, ID: Hashable>(
-        _ title: LocalizedStringKey,
+        _ title: LocalizedStringResource,
         items: [Item],
         selection: Binding<Set<ID>>,
         id keyPath: KeyPath<Item, ID>,

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct ScoreSortAndFilter: View {
 
     @Binding var isShowingOnlyPlayDataWithScores: Bool
-    @Binding var difficultyToShow: IIDXDifficulty
-    @Binding var levelToShow: IIDXLevel
-    @Binding var clearTypeToShow: IIDXClearType
-    @Binding var djLevelToShow: IIDXDJLevel
-    @Binding var versionToShow: String
+    @Binding var difficultiesToShow: Set<IIDXDifficulty>
+    @Binding var levelsToShow: Set<IIDXLevel>
+    @Binding var clearTypesToShow: Set<IIDXClearType>
+    @Binding var djLevelsToShow: Set<IIDXDJLevel>
+    @Binding var versionsToShow: Set<String>
     @Binding var sortMode: SortMode
     @Binding var sortOrder: SortOrder
     @Binding var isSystemChangingFilterAndSort: Bool
@@ -34,19 +34,21 @@ struct ScoreSortAndFilter: View {
         // Sort
         Menu("Shared.Sort", systemImage: "arrow.up.arrow.down") {
             Picker("Shared.Sort", selection: $sortMode) {
-                if levelToShow != .all {
+                if levelsToShow.count == 1 {
                     ForEach(SortMode.whenLevelFiltered, id: \.self) { sortMode in
                         Text(LocalizedStringKey(sortMode.rawValue))
                             .tag(sortMode)
                     }
-                } else if difficultyToShow != .all {
+                } else if difficultiesToShow.count == 1 {
                     ForEach(SortMode.whenDifficultyFiltered, id: \.self) { sortMode in
                         Text(LocalizedStringKey(sortMode.rawValue))
                             .tag(sortMode)
                     }
                 } else {
-                    Text(LocalizedStringKey(SortMode.title.rawValue))
-                        .tag(SortMode.title)
+                    ForEach(SortMode.defaultModes, id: \.self) { sortMode in
+                        Text(LocalizedStringKey(sortMode.rawValue))
+                            .tag(sortMode)
+                    }
                 }
             }
             .pickerStyle(.inline)
@@ -69,11 +71,11 @@ struct ScoreSortAndFilter: View {
         .sheet(isPresented: $isShowingFilterSheet) {
             ScoreFilterSheet(
                 isShowingOnlyPlayDataWithScores: $isShowingOnlyPlayDataWithScores,
-                difficultyToShow: $difficultyToShow,
-                levelToShow: $levelToShow,
-                clearTypeToShow: $clearTypeToShow,
-                djLevelToShow: $djLevelToShow,
-                versionToShow: $versionToShow,
+                difficultiesToShow: $difficultiesToShow,
+                levelsToShow: $levelsToShow,
+                clearTypesToShow: $clearTypesToShow,
+                djLevelsToShow: $djLevelsToShow,
+                versionsToShow: $versionsToShow,
                 isSystemChangingFilterAndSort: $isSystemChangingFilterAndSort,
                 isGenreVisible: $isGenreVisible,
                 isArtistVisible: $isArtistVisible,
@@ -94,11 +96,11 @@ struct ScoreSortAndFilter: View {
 struct ScoreFilterSheet: View {
 
     @Binding var isShowingOnlyPlayDataWithScores: Bool
-    @Binding var difficultyToShow: IIDXDifficulty
-    @Binding var levelToShow: IIDXLevel
-    @Binding var clearTypeToShow: IIDXClearType
-    @Binding var djLevelToShow: IIDXDJLevel
-    @Binding var versionToShow: String
+    @Binding var difficultiesToShow: Set<IIDXDifficulty>
+    @Binding var levelsToShow: Set<IIDXLevel>
+    @Binding var clearTypesToShow: Set<IIDXClearType>
+    @Binding var djLevelsToShow: Set<IIDXDJLevel>
+    @Binding var versionsToShow: Set<String>
     @Binding var isSystemChangingFilterAndSort: Bool
     @Binding var isGenreVisible: Bool
     @Binding var isArtistVisible: Bool
@@ -115,63 +117,48 @@ struct ScoreFilterSheet: View {
         NavigationStack {
             List {
                 Section(.sharedFilter) {
-                    Picker(.sharedLevel, selection: $levelToShow) {
-                        Text(.sharedAll)
-                            .tag(IIDXLevel.all)
-                        Divider()
-                        ForEach(IIDXLevel.sorted, id: \.self) { sortLevel in
-                            Text(LocalizedStringKey(sortLevel.rawValue))
-                                .tag(sortLevel)
-                        }
-                    }
-                    Picker(.sharedDifficulty, selection: $difficultyToShow) {
-                        Text(.sharedAll)
-                            .tag(IIDXDifficulty.all)
-                        Divider()
-                        ForEach(IIDXDifficulty.sorted, id: \.self) { sortDifficulty in
-                            Text("LEVEL \(sortDifficulty.rawValue)")
-                                .tag(sortDifficulty)
-                        }
-                    }
-                    Picker("Shared.IIDX.ClearType", selection: $clearTypeToShow) {
-                        Text(.sharedAll)
-                            .tag(IIDXClearType.all)
-                        Divider()
-                        ForEach(IIDXClearType.sorted, id: \.self) { sortClearType in
-                            Text(LocalizedStringKey(sortClearType.rawValue))
-                                .tag(sortClearType)
-                        }
-                    }
-                    Picker("Shared.IIDX.DJLevel", selection: $djLevelToShow) {
-                        Text(.sharedAll)
-                            .tag(IIDXDJLevel.all)
-                        Divider()
-                        ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { sortDJLevel in
-                            Text(verbatim: sortDJLevel.rawValue)
-                                .tag(sortDJLevel)
-                        }
-                    }
-                    Picker(.sharedVersion, selection: $versionToShow) {
-                        Text(.sharedAll)
-                            .tag("")
-                        Divider()
-                        ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
-                            Text(verbatim: version.marketingName)
-                                .tag(version.marketingName)
-                        }
-                    }
+                    multiSelectMenu(
+                        .sharedLevel,
+                        items: IIDXLevel.sorted,
+                        selection: $levelsToShow,
+                        label: { Text(LocalizedStringKey($0.rawValue)) }
+                    )
+                    multiSelectMenu(
+                        .sharedDifficulty,
+                        items: IIDXDifficulty.sorted,
+                        selection: $difficultiesToShow,
+                        label: { Text("LEVEL \($0.rawValue)") }
+                    )
+                    multiSelectMenu(
+                        "Shared.IIDX.ClearType",
+                        items: IIDXClearType.sorted,
+                        selection: $clearTypesToShow,
+                        label: { Text(LocalizedStringKey($0.rawValue)) }
+                    )
+                    multiSelectMenu(
+                        "Shared.IIDX.DJLevel",
+                        items: IIDXDJLevel.sorted.reversed(),
+                        selection: $djLevelsToShow,
+                        label: { Text(verbatim: $0.rawValue) }
+                    )
+                    multiSelectMenu(
+                        .sharedVersion,
+                        items: IIDXVersion.allCases.reversed(),
+                        selection: $versionsToShow,
+                        id: \.marketingName,
+                        label: { Text(verbatim: $0.marketingName) }
+                    )
                     Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
                         isSystemChangingFilterAndSort = true
-                        difficultyToShow = .all
-                        levelToShow = .all
-                        clearTypeToShow = .all
-                        djLevelToShow = .all
-                        versionToShow = ""
+                        difficultiesToShow = []
+                        levelsToShow = []
+                        clearTypesToShow = []
+                        djLevelsToShow = []
+                        versionsToShow = []
                         isSystemChangingFilterAndSort = false
                         onReset()
                     }
                 }
-                .pickerStyle(.menu)
                 Section("More.PlayDataDisplay.Header") {
                     Toggle(
                         .scoresFilterShowWithScoreOnly, systemImage: "trophy.fill",
@@ -202,5 +189,91 @@ struct ScoreFilterSheet: View {
                 }
             }
         }
+    }
+
+    // MARK: Multi-Select Menu (Hashable items)
+
+    private func multiSelectMenu<Item: Hashable>(
+        _ title: LocalizedStringKey,
+        items: [Item],
+        selection: Binding<Set<Item>>,
+        label: @escaping (Item) -> Text
+    ) -> some View {
+        Menu {
+            ForEach(items, id: \.self) { item in
+                Button {
+                    if selection.wrappedValue.contains(item) {
+                        selection.wrappedValue.remove(item)
+                    } else {
+                        selection.wrappedValue.insert(item)
+                    }
+                } label: {
+                    if selection.wrappedValue.contains(item) {
+                        Label { label(item) } icon: {
+                            Image(systemName: "checkmark")
+                        }
+                    } else {
+                        label(item)
+                    }
+                }
+            }
+        } label: {
+            LabeledContent {
+                if selection.wrappedValue.isEmpty {
+                    Text(.sharedAll)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(verbatim: "\(selection.wrappedValue.count)")
+                        .foregroundStyle(.secondary)
+                }
+            } label: {
+                Text(title)
+            }
+        }
+        .menuActionDismissBehavior(.disabled)
+    }
+
+    // MARK: Multi-Select Menu (custom ID key path for non-Hashable display)
+
+    private func multiSelectMenu<Item: Hashable, ID: Hashable>(
+        _ title: LocalizedStringKey,
+        items: [Item],
+        selection: Binding<Set<ID>>,
+        id keyPath: KeyPath<Item, ID>,
+        label: @escaping (Item) -> Text
+    ) -> some View {
+        Menu {
+            ForEach(items, id: keyPath) { item in
+                let itemID = item[keyPath: keyPath]
+                Button {
+                    if selection.wrappedValue.contains(itemID) {
+                        selection.wrappedValue.remove(itemID)
+                    } else {
+                        selection.wrappedValue.insert(itemID)
+                    }
+                } label: {
+                    if selection.wrappedValue.contains(itemID) {
+                        Label { label(item) } icon: {
+                            Image(systemName: "checkmark")
+                        }
+                    } else {
+                        label(item)
+                    }
+                }
+            }
+        } label: {
+            LabeledContent {
+                if selection.wrappedValue.isEmpty {
+                    Text(.sharedAll)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(verbatim: "\(selection.wrappedValue.count)")
+                        .foregroundStyle(.secondary)
+                }
+            } label: {
+                Text(title)
+            }
+        }
+        .menuActionDismissBehavior(.disabled)
     }
 }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -34,21 +34,9 @@ struct ScoreSortAndFilter: View {
         // Sort
         Menu("Shared.Sort", systemImage: "arrow.up.arrow.down") {
             Picker("Shared.Sort", selection: $sortMode) {
-                if levelsToShow.count == 1 {
-                    ForEach(SortMode.whenLevelFiltered, id: \.self) { sortMode in
-                        Text(LocalizedStringKey(sortMode.rawValue))
-                            .tag(sortMode)
-                    }
-                } else if difficultiesToShow.count == 1 {
-                    ForEach(SortMode.whenDifficultyFiltered, id: \.self) { sortMode in
-                        Text(LocalizedStringKey(sortMode.rawValue))
-                            .tag(sortMode)
-                    }
-                } else {
-                    ForEach(SortMode.defaultModes, id: \.self) { sortMode in
-                        Text(LocalizedStringKey(sortMode.rawValue))
-                            .tag(sortMode)
-                    }
+                ForEach(SortMode.whenLevelFiltered, id: \.self) { sortMode in
+                    Text(LocalizedStringKey(sortMode.rawValue))
+                        .tag(sortMode)
                 }
             }
             .pickerStyle(.inline)

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -111,6 +111,8 @@ struct ScoreFilterSheet: View {
     @Binding var isLastPlayDateVisible: Bool
     var onReset: () -> Void
 
+    @AppStorage(wrappedValue: false, "ScoresView.BeginnerLevelHidden") var isBeginnerLevelHidden: Bool
+
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -118,7 +120,8 @@ struct ScoreFilterSheet: View {
             List {
                 Section(.sharedFilter) {
                     DisclosureGroup {
-                        ForEach(IIDXLevel.sorted, id: \.self) { level in
+                        ForEach(IIDXLevel.sorted.filter({ !isBeginnerLevelHidden || $0 != .beginner }),
+                                id: \.self) { level in
                             SelectableRow(
                                 isSelected: levelsToShow.contains(level)
                             ) {

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -106,6 +106,18 @@ struct ScoreFilterSheet: View {
     var body: some View {
         NavigationStack {
             List {
+                Section {
+                    Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
+                        isSystemChangingFilterAndSort = true
+                        difficultiesToShow = []
+                        levelsToShow = []
+                        clearTypesToShow = []
+                        djLevelsToShow = []
+                        versionsToShow = []
+                        isSystemChangingFilterAndSort = false
+                        onReset()
+                    }
+                }
                 Section(.sharedFilter) {
                     DisclosureGroup {
                         ForEach(IIDXLevel.sorted.filter({ !isBeginnerLevelHidden || $0 != .beginner }),
@@ -199,22 +211,14 @@ struct ScoreFilterSheet: View {
                     } label: {
                         FilterDisclosureLabel(.sharedVersion, count: versionsToShow.count)
                     }
-                    Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
-                        isSystemChangingFilterAndSort = true
-                        difficultiesToShow = []
-                        levelsToShow = []
-                        clearTypesToShow = []
-                        djLevelsToShow = []
-                        versionsToShow = []
-                        isSystemChangingFilterAndSort = false
-                        onReset()
-                    }
                 }
-                Section("More.PlayDataDisplay.Header") {
+                Section {
                     Toggle(
                         .scoresFilterShowWithScoreOnly, systemImage: "trophy.fill",
                         isOn: $isShowingOnlyPlayDataWithScores
                     )
+                }
+                Section("More.PlayDataDisplay.Header") {
                     Toggle("More.PlayDataDisplay.ShowGenre", isOn: $isGenreVisible)
                     Toggle("More.PlayDataDisplay.ShowArtist", isOn: $isArtistVisible)
                     Toggle("More.PlayDataDisplay.ShowLevel", isOn: $isLevelVisible)

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -116,83 +116,98 @@ struct ScoreFilterSheet: View {
     var body: some View {
         NavigationStack {
             List {
-                Section(.sharedLevel) {
-
-                    ForEach(IIDXLevel.sorted, id: \.self) { level in
-                        SelectableRow(
-                            isSelected: levelsToShow.contains(level)
-                        ) {
-                            Text(LocalizedStringKey(level.rawValue))
-                        } action: {
-                            if levelsToShow.contains(level) {
-                                levelsToShow.remove(level)
-                            } else {
-                                levelsToShow.insert(level)
+                Section(.sharedFilter) {
+                    DisclosureGroup {
+                        ForEach(IIDXLevel.sorted, id: \.self) { level in
+                            SelectableRow(
+                                isSelected: levelsToShow.contains(level)
+                            ) {
+                                Text(LocalizedStringKey(level.rawValue))
+                            } action: {
+                                if levelsToShow.contains(level) {
+                                    levelsToShow.remove(level)
+                                } else {
+                                    levelsToShow.insert(level)
+                                }
                             }
                         }
+                    } label: {
+                        FilterDisclosureLabel(.sharedLevel, count: levelsToShow.count)
                     }
-                }
-                Section(.sharedDifficulty) {
-                    ForEach(IIDXDifficulty.sorted, id: \.self) { difficulty in
-                        SelectableRow(
-                            isSelected: difficultiesToShow.contains(difficulty)
-                        ) {
-                            Text("LEVEL \(difficulty.rawValue)")
-                        } action: {
-                            if difficultiesToShow.contains(difficulty) {
-                                difficultiesToShow.remove(difficulty)
-                            } else {
-                                difficultiesToShow.insert(difficulty)
+                    DisclosureGroup {
+                        ForEach(IIDXDifficulty.sorted, id: \.self) { difficulty in
+                            SelectableRow(
+                                isSelected: difficultiesToShow.contains(difficulty)
+                            ) {
+                                Text("LEVEL \(difficulty.rawValue)")
+                            } action: {
+                                if difficultiesToShow.contains(difficulty) {
+                                    difficultiesToShow.remove(difficulty)
+                                } else {
+                                    difficultiesToShow.insert(difficulty)
+                                }
                             }
                         }
+                    } label: {
+                        FilterDisclosureLabel(.sharedDifficulty, count: difficultiesToShow.count)
                     }
-                }
-                Section("Shared.IIDX.ClearType") {
-                    ForEach(IIDXClearType.sorted, id: \.self) { clearType in
-                        SelectableRow(
-                            isSelected: clearTypesToShow.contains(clearType)
-                        ) {
-                            Text(LocalizedStringKey(clearType.rawValue))
-                        } action: {
-                            if clearTypesToShow.contains(clearType) {
-                                clearTypesToShow.remove(clearType)
-                            } else {
-                                clearTypesToShow.insert(clearType)
+                    DisclosureGroup {
+                        ForEach(IIDXClearType.sorted, id: \.self) { clearType in
+                            SelectableRow(
+                                isSelected: clearTypesToShow.contains(clearType)
+                            ) {
+                                Text(LocalizedStringKey(clearType.rawValue))
+                            } action: {
+                                if clearTypesToShow.contains(clearType) {
+                                    clearTypesToShow.remove(clearType)
+                                } else {
+                                    clearTypesToShow.insert(clearType)
+                                }
                             }
                         }
+                    } label: {
+                        FilterDisclosureLabel(
+                            LocalizedStringResource("Shared.IIDX.ClearType"),
+                            count: clearTypesToShow.count
+                        )
                     }
-                }
-                Section("Shared.IIDX.DJLevel") {
-                    ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { djLevel in
-                        SelectableRow(
-                            isSelected: djLevelsToShow.contains(djLevel)
-                        ) {
-                            Text(verbatim: djLevel.rawValue)
-                        } action: {
-                            if djLevelsToShow.contains(djLevel) {
-                                djLevelsToShow.remove(djLevel)
-                            } else {
-                                djLevelsToShow.insert(djLevel)
+                    DisclosureGroup {
+                        ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { djLevel in
+                            SelectableRow(
+                                isSelected: djLevelsToShow.contains(djLevel)
+                            ) {
+                                Text(verbatim: djLevel.rawValue)
+                            } action: {
+                                if djLevelsToShow.contains(djLevel) {
+                                    djLevelsToShow.remove(djLevel)
+                                } else {
+                                    djLevelsToShow.insert(djLevel)
+                                }
                             }
                         }
+                    } label: {
+                        FilterDisclosureLabel(
+                            LocalizedStringResource("Shared.IIDX.DJLevel"),
+                            count: djLevelsToShow.count
+                        )
                     }
-                }
-                Section(.sharedVersion) {
-                    ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
-                        SelectableRow(
-                            isSelected: versionsToShow.contains(version.marketingName)
-                        ) {
-                            Text(verbatim: version.marketingName)
-                        } action: {
-                            if versionsToShow.contains(version.marketingName) {
-                                versionsToShow.remove(version.marketingName)
-                            } else {
-                                versionsToShow.insert(version.marketingName)
+                    DisclosureGroup {
+                        ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
+                            SelectableRow(
+                                isSelected: versionsToShow.contains(version.marketingName)
+                            ) {
+                                Text(verbatim: version.marketingName)
+                            } action: {
+                                if versionsToShow.contains(version.marketingName) {
+                                    versionsToShow.remove(version.marketingName)
+                                } else {
+                                    versionsToShow.insert(version.marketingName)
+                                }
                             }
                         }
+                    } label: {
+                        FilterDisclosureLabel(.sharedVersion, count: versionsToShow.count)
                     }
-                }
-                Section {
                     Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
                         isSystemChangingFilterAndSort = true
                         difficultiesToShow = []
@@ -233,6 +248,31 @@ struct ScoreFilterSheet: View {
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+private struct FilterDisclosureLabel: View {
+
+    let title: LocalizedStringResource
+    let count: Int
+
+    init(_ title: LocalizedStringResource, count: Int) {
+        self.title = title
+        self.count = count
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            if count > 0 {
+                Text(verbatim: "\(count)")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(.sharedAll)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -130,13 +130,13 @@ struct ScoreFilterSheet: View {
                         label: { Text("LEVEL \($0.rawValue)") }
                     )
                     multiSelectMenu(
-                        .sharedIIDXClearType,
+                        LocalizedStringResource("Shared.IIDX.ClearType"),
                         items: IIDXClearType.sorted,
                         selection: $clearTypesToShow,
                         label: { Text(LocalizedStringKey($0.rawValue)) }
                     )
                     multiSelectMenu(
-                        .sharedIIDXDJLevel,
+                        LocalizedStringResource("Shared.IIDX.DJLevel"),
                         items: IIDXDJLevel.sorted.reversed(),
                         selection: $djLevelsToShow,
                         label: { Text(verbatim: $0.rawValue) }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -28,6 +28,8 @@ struct ScoreSortAndFilter: View {
     @AppStorage(wrappedValue: true, "ScoresView.ScoreVisible") var isScoreVisible: Bool
     @AppStorage(wrappedValue: false, "ScoresView.LastPlayDateVisible") var isLastPlayDateVisible: Bool
 
+    @State private var isShowingFilterSheet: Bool = false
+
     var body: some View {
         // Sort
         Menu("Shared.Sort", systemImage: "arrow.up.arrow.down") {
@@ -61,81 +63,144 @@ struct ScoreSortAndFilter: View {
         .menuActionDismissBehavior(.disabled)
 
         // Filter
-        Menu("Shared.Filter", systemImage: "line.3.horizontal.decrease") {
-            Toggle(
-                .scoresFilterShowWithScoreOnly, systemImage: "trophy.fill",
-                isOn: $isShowingOnlyPlayDataWithScores
+        Button("Shared.Filter", systemImage: "line.3.horizontal.decrease") {
+            isShowingFilterSheet = true
+        }
+        .sheet(isPresented: $isShowingFilterSheet) {
+            ScoreFilterSheet(
+                isShowingOnlyPlayDataWithScores: $isShowingOnlyPlayDataWithScores,
+                difficultyToShow: $difficultyToShow,
+                levelToShow: $levelToShow,
+                clearTypeToShow: $clearTypeToShow,
+                djLevelToShow: $djLevelToShow,
+                versionToShow: $versionToShow,
+                isSystemChangingFilterAndSort: $isSystemChangingFilterAndSort,
+                isGenreVisible: $isGenreVisible,
+                isArtistVisible: $isArtistVisible,
+                isLevelVisible: $isLevelVisible,
+                isDJLevelVisible: $isDJLevelVisible,
+                isScoreRateVisible: $isScoreRateVisible,
+                isScoreVisible: $isScoreVisible,
+                isLastPlayDateVisible: $isLastPlayDateVisible,
+                onReset: onReset
             )
-            Section(.sharedFilter) {
-                Picker(.sharedDifficulty, selection: $difficultyToShow) {
-                    Text(.sharedAll)
-                        .tag(IIDXDifficulty.all)
-                    Divider()
-                    ForEach(IIDXDifficulty.sorted, id: \.self) { sortDifficulty in
-                        Text("LEVEL \(sortDifficulty.rawValue)")
-                            .tag(sortDifficulty)
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.hidden)
+            .interactiveDismissDisabled()
+        }
+    }
+}
+
+struct ScoreFilterSheet: View {
+
+    @Binding var isShowingOnlyPlayDataWithScores: Bool
+    @Binding var difficultyToShow: IIDXDifficulty
+    @Binding var levelToShow: IIDXLevel
+    @Binding var clearTypeToShow: IIDXClearType
+    @Binding var djLevelToShow: IIDXDJLevel
+    @Binding var versionToShow: String
+    @Binding var isSystemChangingFilterAndSort: Bool
+    @Binding var isGenreVisible: Bool
+    @Binding var isArtistVisible: Bool
+    @Binding var isLevelVisible: Bool
+    @Binding var isDJLevelVisible: Bool
+    @Binding var isScoreRateVisible: Bool
+    @Binding var isScoreVisible: Bool
+    @Binding var isLastPlayDateVisible: Bool
+    var onReset: () -> Void
+
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section(.sharedFilter) {
+                    Picker(.sharedLevel, selection: $levelToShow) {
+                        Text(.sharedAll)
+                            .tag(IIDXLevel.all)
+                        Divider()
+                        ForEach(IIDXLevel.sorted, id: \.self) { sortLevel in
+                            Text(LocalizedStringKey(sortLevel.rawValue))
+                                .tag(sortLevel)
+                        }
+                    }
+                    Picker(.sharedDifficulty, selection: $difficultyToShow) {
+                        Text(.sharedAll)
+                            .tag(IIDXDifficulty.all)
+                        Divider()
+                        ForEach(IIDXDifficulty.sorted, id: \.self) { sortDifficulty in
+                            Text("LEVEL \(sortDifficulty.rawValue)")
+                                .tag(sortDifficulty)
+                        }
+                    }
+                    Picker("Shared.IIDX.ClearType", selection: $clearTypeToShow) {
+                        Text(.sharedAll)
+                            .tag(IIDXClearType.all)
+                        Divider()
+                        ForEach(IIDXClearType.sorted, id: \.self) { sortClearType in
+                            Text(LocalizedStringKey(sortClearType.rawValue))
+                                .tag(sortClearType)
+                        }
+                    }
+                    Picker("Shared.IIDX.DJLevel", selection: $djLevelToShow) {
+                        Text(.sharedAll)
+                            .tag(IIDXDJLevel.all)
+                        Divider()
+                        ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { sortDJLevel in
+                            Text(verbatim: sortDJLevel.rawValue)
+                                .tag(sortDJLevel)
+                        }
+                    }
+                    Picker(.sharedVersion, selection: $versionToShow) {
+                        Text(.sharedAll)
+                            .tag("")
+                        Divider()
+                        ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
+                            Text(verbatim: version.marketingName)
+                                .tag(version.marketingName)
+                        }
+                    }
+                    Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
+                        isSystemChangingFilterAndSort = true
+                        difficultyToShow = .all
+                        levelToShow = .all
+                        clearTypeToShow = .all
+                        djLevelToShow = .all
+                        versionToShow = ""
+                        isSystemChangingFilterAndSort = false
+                        onReset()
                     }
                 }
-                Picker(.sharedLevel, selection: $levelToShow) {
-                    Text(.sharedAll)
-                        .tag(IIDXLevel.all)
-                    Divider()
-                    ForEach(IIDXLevel.sorted, id: \.self) { sortLevel in
-                        Text(LocalizedStringKey(sortLevel.rawValue))
-                            .tag(sortLevel)
-                    }
-                }
-                Picker("Shared.IIDX.ClearType", selection: $clearTypeToShow) {
-                    Text(.sharedAll)
-                        .tag(IIDXClearType.all)
-                    Divider()
-                    ForEach(IIDXClearType.sorted, id: \.self) { sortClearType in
-                        Text(LocalizedStringKey(sortClearType.rawValue))
-                            .tag(sortClearType)
-                    }
-                }
-                Picker("Shared.IIDX.DJLevel", selection: $djLevelToShow) {
-                    Text(.sharedAll)
-                        .tag(IIDXDJLevel.all)
-                    Divider()
-                    ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { sortDJLevel in
-                        Text(verbatim: sortDJLevel.rawValue)
-                            .tag(sortDJLevel)
-                    }
-                }
-                Picker(.sharedVersion, selection: $versionToShow) {
-                    Text(.sharedAll)
-                        .tag("")
-                    Divider()
-                    ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
-                        Text(verbatim: version.marketingName)
-                            .tag(version.marketingName)
-                    }
-                }
-                Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
-                    isSystemChangingFilterAndSort = true
-                    difficultyToShow = .all
-                    levelToShow = .all
-                    clearTypeToShow = .all
-                    djLevelToShow = .all
-                    versionToShow = ""
-                    sortMode = .title
-                    sortOrder = .ascending
-                    isSystemChangingFilterAndSort = false
-                    onReset()
+                .pickerStyle(.menu)
+                Section("More.PlayDataDisplay.Header") {
+                    Toggle(
+                        .scoresFilterShowWithScoreOnly, systemImage: "trophy.fill",
+                        isOn: $isShowingOnlyPlayDataWithScores
+                    )
+                    Toggle("More.PlayDataDisplay.ShowGenre", isOn: $isGenreVisible)
+                    Toggle("More.PlayDataDisplay.ShowArtist", isOn: $isArtistVisible)
+                    Toggle("More.PlayDataDisplay.ShowLevel", isOn: $isLevelVisible)
+                    Toggle("Shared.IIDX.DJLevel", isOn: $isDJLevelVisible)
+                    Toggle("Shared.Sort.ScoreRate", isOn: $isScoreRateVisible)
+                    Toggle("Shared.Sort.Score", isOn: $isScoreVisible)
+                    Toggle("Shared.Sort.LastPlayDate", isOn: $isLastPlayDateVisible)
                 }
             }
-            .pickerStyle(.menu)
-            Section("More.PlayDataDisplay.Header") {
-                Toggle("More.PlayDataDisplay.ShowGenre", isOn: $isGenreVisible)
-                Toggle("More.PlayDataDisplay.ShowArtist", isOn: $isArtistVisible)
-                Toggle("More.PlayDataDisplay.ShowLevel", isOn: $isLevelVisible)
-                Toggle("Shared.IIDX.DJLevel", isOn: $isDJLevelVisible)
-                Toggle("Shared.Sort.ScoreRate", isOn: $isScoreRateVisible)
-                Toggle("Shared.Sort.Score", isOn: $isScoreVisible)
-                Toggle("Shared.Sort.LastPlayDate", isOn: $isLastPlayDateVisible)
+            .navigationTitle("Shared.Filter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    if #available(iOS 26.0, *) {
+                        Button(role: .confirm) {
+                            dismiss()
+                        }
+                    } else {
+                        Button(.sharedDone) {
+                            dismiss()
+                        }
+                    }
+                }
             }
         }
-        .menuActionDismissBehavior(.disabled)
     }
 }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -116,38 +116,82 @@ struct ScoreFilterSheet: View {
     var body: some View {
         NavigationStack {
             List {
-                Section(.sharedFilter) {
-                    multiSelectMenu(
-                        .sharedLevel,
-                        items: IIDXLevel.sorted,
-                        selection: $levelsToShow,
-                        label: { Text(LocalizedStringKey($0.rawValue)) }
-                    )
-                    multiSelectMenu(
-                        .sharedDifficulty,
-                        items: IIDXDifficulty.sorted,
-                        selection: $difficultiesToShow,
-                        label: { Text("LEVEL \($0.rawValue)") }
-                    )
-                    multiSelectMenu(
-                        LocalizedStringResource("Shared.IIDX.ClearType"),
-                        items: IIDXClearType.sorted,
-                        selection: $clearTypesToShow,
-                        label: { Text(LocalizedStringKey($0.rawValue)) }
-                    )
-                    multiSelectMenu(
-                        LocalizedStringResource("Shared.IIDX.DJLevel"),
-                        items: IIDXDJLevel.sorted.reversed(),
-                        selection: $djLevelsToShow,
-                        label: { Text(verbatim: $0.rawValue) }
-                    )
-                    multiSelectMenu(
-                        .sharedVersion,
-                        items: IIDXVersion.allCases.reversed(),
-                        selection: $versionsToShow,
-                        id: \.marketingName,
-                        label: { Text(verbatim: $0.marketingName) }
-                    )
+                Section(.sharedLevel) {
+                    ForEach(IIDXLevel.sorted, id: \.self) { level in
+                        SelectableRow(
+                            isSelected: levelsToShow.contains(level)
+                        ) {
+                            Text(LocalizedStringKey(level.rawValue))
+                        } action: {
+                            if levelsToShow.contains(level) {
+                                levelsToShow.remove(level)
+                            } else {
+                                levelsToShow.insert(level)
+                            }
+                        }
+                    }
+                }
+                Section(.sharedDifficulty) {
+                    ForEach(IIDXDifficulty.sorted, id: \.self) { difficulty in
+                        SelectableRow(
+                            isSelected: difficultiesToShow.contains(difficulty)
+                        ) {
+                            Text("LEVEL \(difficulty.rawValue)")
+                        } action: {
+                            if difficultiesToShow.contains(difficulty) {
+                                difficultiesToShow.remove(difficulty)
+                            } else {
+                                difficultiesToShow.insert(difficulty)
+                            }
+                        }
+                    }
+                }
+                Section("Shared.IIDX.ClearType") {
+                    ForEach(IIDXClearType.sorted, id: \.self) { clearType in
+                        SelectableRow(
+                            isSelected: clearTypesToShow.contains(clearType)
+                        ) {
+                            Text(LocalizedStringKey(clearType.rawValue))
+                        } action: {
+                            if clearTypesToShow.contains(clearType) {
+                                clearTypesToShow.remove(clearType)
+                            } else {
+                                clearTypesToShow.insert(clearType)
+                            }
+                        }
+                    }
+                }
+                Section("Shared.IIDX.DJLevel") {
+                    ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { djLevel in
+                        SelectableRow(
+                            isSelected: djLevelsToShow.contains(djLevel)
+                        ) {
+                            Text(verbatim: djLevel.rawValue)
+                        } action: {
+                            if djLevelsToShow.contains(djLevel) {
+                                djLevelsToShow.remove(djLevel)
+                            } else {
+                                djLevelsToShow.insert(djLevel)
+                            }
+                        }
+                    }
+                }
+                Section(.sharedVersion) {
+                    ForEach(IIDXVersion.allCases.reversed(), id: \.self) { version in
+                        SelectableRow(
+                            isSelected: versionsToShow.contains(version.marketingName)
+                        ) {
+                            Text(verbatim: version.marketingName)
+                        } action: {
+                            if versionsToShow.contains(version.marketingName) {
+                                versionsToShow.remove(version.marketingName)
+                            } else {
+                                versionsToShow.insert(version.marketingName)
+                            }
+                        }
+                    }
+                }
+                Section {
                     Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
                         isSystemChangingFilterAndSort = true
                         difficultiesToShow = []
@@ -190,90 +234,29 @@ struct ScoreFilterSheet: View {
             }
         }
     }
+}
 
-    // MARK: Multi-Select Menu (Hashable items)
+private struct SelectableRow<Label: View>: View {
 
-    private func multiSelectMenu<Item: Hashable>(
-        _ title: LocalizedStringResource,
-        items: [Item],
-        selection: Binding<Set<Item>>,
-        label: @escaping (Item) -> Text
-    ) -> some View {
-        Menu {
-            ForEach(items, id: \.self) { item in
-                Button {
-                    if selection.wrappedValue.contains(item) {
-                        selection.wrappedValue.remove(item)
-                    } else {
-                        selection.wrappedValue.insert(item)
-                    }
-                } label: {
-                    if selection.wrappedValue.contains(item) {
-                        Label { label(item) } icon: {
-                            Image(systemName: "checkmark")
-                        }
-                    } else {
-                        label(item)
-                    }
-                }
-            }
+    var isSelected: Bool
+    @ViewBuilder var label: Label
+    var action: () -> Void
+
+    var body: some View {
+        Button {
+            action()
         } label: {
-            LabeledContent {
-                if selection.wrappedValue.isEmpty {
-                    Text(.sharedAll)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(verbatim: "\(selection.wrappedValue.count)")
-                        .foregroundStyle(.secondary)
+            HStack {
+                label
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                        .fontWeight(.semibold)
                 }
-            } label: {
-                Text(title)
             }
+            .contentShape(.rect)
         }
-        .menuActionDismissBehavior(.disabled)
-    }
-
-    // MARK: Multi-Select Menu (custom ID key path for non-Hashable display)
-
-    private func multiSelectMenu<Item: Hashable, ID: Hashable>(
-        _ title: LocalizedStringResource,
-        items: [Item],
-        selection: Binding<Set<ID>>,
-        id keyPath: KeyPath<Item, ID>,
-        label: @escaping (Item) -> Text
-    ) -> some View {
-        Menu {
-            ForEach(items, id: keyPath) { item in
-                let itemID = item[keyPath: keyPath]
-                Button {
-                    if selection.wrappedValue.contains(itemID) {
-                        selection.wrappedValue.remove(itemID)
-                    } else {
-                        selection.wrappedValue.insert(itemID)
-                    }
-                } label: {
-                    if selection.wrappedValue.contains(itemID) {
-                        Label { label(item) } icon: {
-                            Image(systemName: "checkmark")
-                        }
-                    } else {
-                        label(item)
-                    }
-                }
-            }
-        } label: {
-            LabeledContent {
-                if selection.wrappedValue.isEmpty {
-                    Text(.sharedAll)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(verbatim: "\(selection.wrappedValue.count)")
-                        .foregroundStyle(.secondary)
-                }
-            } label: {
-                Text(title)
-            }
-        }
-        .menuActionDismissBehavior(.disabled)
+        .buttonStyle(.plain)
     }
 }

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -135,7 +135,8 @@ struct ScoreFilterSheet: View {
                             }
                         }
                     } label: {
-                        FilterDisclosureLabel(.sharedLevel, count: levelsToShow.count)
+                        FilterDisclosureLabel(.sharedLevel, count: levelsToShow.count,
+                                              countLabel: LocalizedStringResource("Shared.Filter.Count.Levels"))
                     }
                     DisclosureGroup {
                         ForEach(IIDXDifficulty.sorted, id: \.self) { difficulty in
@@ -152,7 +153,8 @@ struct ScoreFilterSheet: View {
                             }
                         }
                     } label: {
-                        FilterDisclosureLabel(.sharedDifficulty, count: difficultiesToShow.count)
+                        FilterDisclosureLabel(.sharedDifficulty, count: difficultiesToShow.count,
+                                              countLabel: LocalizedStringResource("Shared.Filter.Count.Difficulties"))
                     }
                     DisclosureGroup {
                         ForEach(IIDXClearType.sorted, id: \.self) { clearType in
@@ -171,7 +173,8 @@ struct ScoreFilterSheet: View {
                     } label: {
                         FilterDisclosureLabel(
                             LocalizedStringResource("Shared.IIDX.ClearType"),
-                            count: clearTypesToShow.count
+                            count: clearTypesToShow.count,
+                            countLabel: LocalizedStringResource("Shared.Filter.Count.ClearTypes")
                         )
                     }
                     DisclosureGroup {
@@ -191,7 +194,8 @@ struct ScoreFilterSheet: View {
                     } label: {
                         FilterDisclosureLabel(
                             LocalizedStringResource("Shared.IIDX.DJLevel"),
-                            count: djLevelsToShow.count
+                            count: djLevelsToShow.count,
+                            countLabel: LocalizedStringResource("Shared.Filter.Count.DJLevels")
                         )
                     }
                     DisclosureGroup {
@@ -209,7 +213,8 @@ struct ScoreFilterSheet: View {
                             }
                         }
                     } label: {
-                        FilterDisclosureLabel(.sharedVersion, count: versionsToShow.count)
+                        FilterDisclosureLabel(.sharedVersion, count: versionsToShow.count,
+                                              countLabel: LocalizedStringResource("Shared.Filter.Count.Versions"))
                     }
                 }
                 Section {
@@ -252,10 +257,12 @@ private struct FilterDisclosureLabel: View {
 
     let title: LocalizedStringResource
     let count: Int
+    let countSuffix: LocalizedStringResource
 
-    init(_ title: LocalizedStringResource, count: Int) {
+    init(_ title: LocalizedStringResource, count: Int, countLabel: LocalizedStringResource) {
         self.title = title
         self.count = count
+        self.countSuffix = countLabel
     }
 
     var body: some View {
@@ -263,7 +270,7 @@ private struct FilterDisclosureLabel: View {
             Text(title)
             Spacer()
             if count > 0 {
-                Text(verbatim: "\(count)")
+                Text("\(count) \(String(localized: countSuffix))")
                     .foregroundStyle(.secondary)
             } else {
                 Text(.sharedAll)

--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -117,6 +117,7 @@ struct ScoreFilterSheet: View {
         NavigationStack {
             List {
                 Section(.sharedLevel) {
+
                     ForEach(IIDXLevel.sorted, id: \.self) { level in
                         SelectableRow(
                             isSelected: levelsToShow.contains(level)
@@ -217,6 +218,7 @@ struct ScoreFilterSheet: View {
                     Toggle("Shared.Sort.LastPlayDate", isOn: $isLastPlayDateVisible)
                 }
             }
+            .listSectionSpacing(.compact)
             .navigationTitle("Shared.Filter")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -99,7 +99,7 @@ extension ScoresView {
     func levelEntries(from records: [IIDXSongRecord]) -> [SongLevelEntry] {
         let difficultyRawValues = Set(difficultiesToShow.map(\.rawValue))
         var entries = records.flatMap { record in
-            Self.allLevels.compactMap { level, keyPath in
+            Self.allLevels.compactMap { level, keyPath -> SongLevelEntry? in
                 let score = record[keyPath: keyPath]
                 guard score.difficulty > 0 else { return nil }
                 if level == .beginner && isBeginnerLevelHidden { return nil }

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -97,12 +97,18 @@ extension ScoresView {
     }
 
     func levelEntries(from records: [IIDXSongRecord]) -> [SongLevelEntry] {
-        records.flatMap { record in
+        let difficultyRawValues = Set(difficultiesToShow.map(\.rawValue))
+        return records.flatMap { record in
             Self.allLevels.compactMap { level, keyPath in
                 let score = record[keyPath: keyPath]
                 guard score.difficulty > 0 else { return nil }
                 if level == .beginner && isBeginnerLevelHidden { return nil }
-                guard levelsToShow.isEmpty || levelsToShow.contains(level) else { return nil }
+                if !levelsToShow.isEmpty && !levelsToShow.contains(level) { return nil }
+                if !difficultiesToShow.isEmpty && !difficultyRawValues.contains(score.difficulty) { return nil }
+                if !clearTypesToShow.isEmpty &&
+                    !clearTypesToShow.contains(where: { $0.rawValue == score.clearType }) { return nil }
+                if !djLevelsToShow.isEmpty &&
+                    !djLevelsToShow.contains(where: { $0.rawValue == score.djLevel }) { return nil }
                 return SongLevelEntry(songRecord: record, level: level, score: score)
             }
         }

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -89,10 +89,23 @@ extension ScoresView {
         }
     }
 
-    func scoreRate(for songRecord: IIDXSongRecord, of level: IIDXLevel,
-                   or difficulty: IIDXDifficulty) -> Float? {
-        return songRecordClearRates[songRecord]?[
-            songRecord.level(for: level, or: difficulty)]
+    struct SongLevelEntry {
+        let songRecord: IIDXSongRecord
+        let level: IIDXLevel
+        let score: IIDXLevelScore
+        var id: String { "\(songRecord.title)_\(level.rawValue)" }
+    }
+
+    func levelEntries(from records: [IIDXSongRecord]) -> [SongLevelEntry] {
+        records.flatMap { record in
+            Self.allLevels.compactMap { level, keyPath in
+                let score = record[keyPath: keyPath]
+                guard score.difficulty > 0 else { return nil }
+                if level == .beginner && isBeginnerLevelHidden { return nil }
+                guard levelsToShow.isEmpty || levelsToShow.contains(level) else { return nil }
+                return SongLevelEntry(songRecord: record, level: level, score: score)
+            }
+        }
     }
 
     func noteCount(for songRecord: IIDXSongRecord, of level: IIDXLevel) -> Int? {

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -96,6 +96,7 @@ extension ScoresView {
         var id: String { "\(songRecord.title)_\(level.rawValue)" }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     func levelEntries(from records: [IIDXSongRecord]) -> [SongLevelEntry] {
         let difficultyRawValues = Set(difficultiesToShow.map(\.rawValue))
         var entries = records.flatMap { record in

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -98,7 +98,7 @@ extension ScoresView {
 
     func levelEntries(from records: [IIDXSongRecord]) -> [SongLevelEntry] {
         let difficultyRawValues = Set(difficultiesToShow.map(\.rawValue))
-        return records.flatMap { record in
+        var entries = records.flatMap { record in
             Self.allLevels.compactMap { level, keyPath in
                 let score = record[keyPath: keyPath]
                 guard score.difficulty > 0 else { return nil }
@@ -112,6 +112,61 @@ extension ScoresView {
                 return SongLevelEntry(songRecord: record, level: level, score: score)
             }
         }
+
+        let isAscending = sortOrder == .ascending
+        switch sortMode {
+        case .title:
+            entries.sort { isAscending ? $0.songRecord.title < $1.songRecord.title
+                : $0.songRecord.title > $1.songRecord.title }
+        case .clearType:
+            let order = IIDXClearType.sortedStrings
+            entries.sort { lhs, rhs in
+                let li = order.firstIndex(of: lhs.score.clearType)
+                let ri = order.firstIndex(of: rhs.score.clearType)
+                if li == ri { return lhs.songRecord.title < rhs.songRecord.title }
+                guard let li, let ri else { return li != nil }
+                return isAscending ? li < ri : li > ri
+            }
+        case .djLevel:
+            let order = IIDXDJLevel.sorted
+            entries.sort { lhs, rhs in
+                let li = order.firstIndex(of: IIDXDJLevel(rawValue: lhs.score.djLevel) ?? .none)
+                let ri = order.firstIndex(of: IIDXDJLevel(rawValue: rhs.score.djLevel) ?? .none)
+                if li == ri { return lhs.songRecord.title < rhs.songRecord.title }
+                guard let li, let ri else { return li != nil }
+                return isAscending ? li < ri : li > ri
+            }
+        case .scoreRate:
+            entries.sort { lhs, rhs in
+                let lr = songRecordClearRates[lhs.songRecord]?[lhs.level] ?? 0
+                let rr = songRecordClearRates[rhs.songRecord]?[rhs.level] ?? 0
+                if lr == rr { return lhs.songRecord.title < rhs.songRecord.title }
+                return isAscending ? lr < rr : lr > rr
+            }
+        case .score:
+            entries.sort { lhs, rhs in
+                if lhs.score.score == rhs.score.score { return lhs.songRecord.title < rhs.songRecord.title }
+                return isAscending ? lhs.score.score < rhs.score.score
+                    : lhs.score.score > rhs.score.score
+            }
+        case .missCount:
+            entries.sort { lhs, rhs in
+                if lhs.score.missCount == rhs.score.missCount { return lhs.songRecord.title < rhs.songRecord.title }
+                return isAscending ? lhs.score.missCount < rhs.score.missCount
+                    : lhs.score.missCount > rhs.score.missCount
+            }
+        case .difficulty:
+            entries.sort { lhs, rhs in
+                if lhs.score.difficulty == rhs.score.difficulty { return lhs.songRecord.title < rhs.songRecord.title }
+                return isAscending ? lhs.score.difficulty < rhs.score.difficulty
+                    : lhs.score.difficulty > rhs.score.difficulty
+            }
+        case .lastPlayDate:
+            entries.sort { isAscending ? $0.songRecord.lastPlayDate < $1.songRecord.lastPlayDate
+                : $0.songRecord.lastPlayDate > $1.songRecord.lastPlayDate }
+        }
+
+        return entries
     }
 
     func noteCount(for songRecord: IIDXSongRecord, of level: IIDXLevel) -> Int? {

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -19,11 +19,11 @@ extension ScoresView {
                     on: playDataDate,
                     filters: FilterOptions(playType: playTypeToShow,
                                            onlyPlayDataWithScores: isShowingOnlyPlayDataWithScores,
-                                           level: levelToShow,
-                                           difficulty: difficultyToShow,
-                                           clearType: clearTypeToShow,
-                                           djLevel: djLevelToShow,
-                                           version: versionToShow),
+                                           levels: levelsToShow,
+                                           difficulties: difficultiesToShow,
+                                           clearTypes: clearTypesToShow,
+                                           djLevels: djLevelsToShow,
+                                           versions: versionsToShow),
                     sortOptions: SortOptions(mode: sortMode, order: sortOrder)
                 )
                 let songCompactTitles = await actor.songCompactTitles()
@@ -89,7 +89,8 @@ extension ScoresView {
         }
     }
 
-    func scoreRate(for songRecord: IIDXSongRecord, of level: IIDXLevel, or difficulty: IIDXDifficulty) -> Float? {
+    func scoreRate(for songRecord: IIDXSongRecord, of level: IIDXLevel,
+                   or difficulty: IIDXDifficulty) -> Float? {
         return songRecordClearRates[songRecord]?[
             songRecord.level(for: level, or: difficulty)]
     }

--- a/DJDX/Views/Scores/ScoresView+Functions.swift
+++ b/DJDX/Views/Scores/ScoresView+Functions.swift
@@ -11,7 +11,7 @@ import SwiftUI
 extension ScoresView {
 
     func reloadDisplay() {
-        withAnimation(.snappy.speed(2.0)) {
+        withAnimation(.smooth.speed(2.0)) {
             dataState = .loading
         } completion: {
             Task.detached {
@@ -30,7 +30,7 @@ extension ScoresView {
                 let songNoteCounts = await actor.songNoteCounts
 
                 await MainActor.run {
-                    withAnimation(.snappy.speed(2.0)) {
+                    withAnimation(.smooth.speed(2.0)) {
                         if let songRecords {
                             // Calculate clear rates
                             let noteCounts: [String: IIDXNoteCount] = songCompactTitles

--- a/DJDX/Views/Scores/ScoresView.swift
+++ b/DJDX/Views/Scores/ScoresView.swift
@@ -43,6 +43,8 @@ struct ScoresView: View {
 
     let actor = DataFetcher()
 
+    @AppStorage(wrappedValue: false, "ScoresView.BeginnerLevelHidden") var isBeginnerLevelHidden: Bool
+
     @Namespace var scoresNamespace
 
     var effectiveLevel: IIDXLevel {
@@ -52,6 +54,14 @@ struct ScoresView: View {
     var effectiveDifficulty: IIDXDifficulty {
         difficultiesToShow.count == 1 ? difficultiesToShow.first! : .all
     }
+
+    private static let allLevels: [(IIDXLevel, KeyPath<IIDXSongRecord, IIDXLevelScore>)] = [
+        (.beginner, \.beginnerScore),
+        (.normal, \.normalScore),
+        (.hyper, \.hyperScore),
+        (.another, \.anotherScore),
+        (.leggendaria, \.leggendariaScore)
+    ]
 
     var conditionsForReload: [String] {
         [isShowingOnlyPlayDataWithScores.description,
@@ -71,20 +81,17 @@ struct ScoresView: View {
     var body: some View {
         NavigationStack(path: $navigationManager[.scores]) {
             List {
-                ForEach((searchResults != nil ? searchResults ?? [] : songRecords ?? []),
-                        id: \.title) { songRecord in
+                ForEach(levelEntries(from: searchResults ?? songRecords ?? []),
+                        id: \.id) { entry in
                     Button {
-                        navigationManager.push(.scoreViewer(songRecord: songRecord), for: .scores)
+                        navigationManager.push(.scoreViewer(songRecord: entry.songRecord), for: .scores)
                     } label: {
                         ScoreRow(
                             namespace: scoresNamespace,
-                            songRecord: songRecord,
-                            scoreRate: scoreRate(for: songRecord,
-                                                 of: effectiveLevel,
-                                                 or: effectiveDifficulty),
-                            levelToShow: effectiveLevel,
-                            difficultyToShow: effectiveDifficulty,
-                            levelsToShow: levelsToShow
+                            songRecord: entry.songRecord,
+                            level: entry.level,
+                            score: entry.score,
+                            scoreRate: songRecordClearRates[entry.songRecord]?[entry.level]
                         )
                     }
                     .listRowInsets(.init(top: 0.0, leading: 0.0, bottom: 0.0, trailing: 0.0))

--- a/DJDX/Views/Scores/ScoresView.swift
+++ b/DJDX/Views/Scores/ScoresView.swift
@@ -83,7 +83,8 @@ struct ScoresView: View {
                                                  of: effectiveLevel,
                                                  or: effectiveDifficulty),
                             levelToShow: effectiveLevel,
-                            difficultyToShow: effectiveDifficulty
+                            difficultyToShow: effectiveDifficulty,
+                            levelsToShow: levelsToShow
                         )
                     }
                     .listRowInsets(.init(top: 0.0, leading: 0.0, bottom: 0.0, trailing: 0.0))

--- a/DJDX/Views/Scores/ScoresView.swift
+++ b/DJDX/Views/Scores/ScoresView.swift
@@ -84,7 +84,10 @@ struct ScoresView: View {
                 ForEach(levelEntries(from: searchResults ?? songRecords ?? []),
                         id: \.id) { entry in
                     Button {
-                        navigationManager.push(.scoreViewer(songRecord: entry.songRecord), for: .scores)
+                        navigationManager.push(
+                            .scoreViewer(songRecord: entry.songRecord, initialLevel: entry.level),
+                            for: .scores
+                        )
                     } label: {
                         ScoreRow(
                             namespace: scoresNamespace,
@@ -242,9 +245,9 @@ struct ScoresView: View {
             }
             .navigationDestination(for: ViewPath.self) { viewPath in
                 switch viewPath {
-                case .scoreViewer(let songRecord):
+                case .scoreViewer(let songRecord, let initialLevel):
                     ScoreViewer(songRecord: songRecord, noteCount: noteCount,
-                                initialLevel: songRecord.level(for: effectiveLevel, or: effectiveDifficulty))
+                                initialLevel: initialLevel)
                     .automaticNavigationTransition(id: songRecord.title, in: scoresNamespace)
                 case .scoreHistory(let songTitle, let level, let noteCount):
                     ScoreHistoryViewer(songTitle: songTitle, level: level, noteCount: noteCount)

--- a/DJDX/Views/Scores/ScoresView.swift
+++ b/DJDX/Views/Scores/ScoresView.swift
@@ -15,11 +15,11 @@ struct ScoresView: View {
 
     @AppStorage(wrappedValue: .single, "ScoresView.PlayTypeFilter") var playTypeToShow: IIDXPlayType
     @AppStorage(wrappedValue: true, "ScoresView.ScoreAvailableOnlyFilter") var isShowingOnlyPlayDataWithScores: Bool
-    @AppStorage(wrappedValue: .all, "ScoresView.DifficultyFilter") var difficultyToShow: IIDXDifficulty
-    @AppStorage(wrappedValue: .all, "ScoresView.LevelFilter") var levelToShow: IIDXLevel
-    @AppStorage(wrappedValue: .all, "ScoresView.ClearTypeFilter") var clearTypeToShow: IIDXClearType
-    @AppStorage(wrappedValue: .all, "ScoresView.DJLevelFilter") var djLevelToShow: IIDXDJLevel
-    @AppStorage(wrappedValue: "", "ScoresView.VersionFilter") var versionToShow: String
+    @AppStorage(wrappedValue: [], "ScoresView.DifficultyFilters") var difficultiesToShow: Set<IIDXDifficulty>
+    @AppStorage(wrappedValue: [], "ScoresView.LevelFilters") var levelsToShow: Set<IIDXLevel>
+    @AppStorage(wrappedValue: [], "ScoresView.ClearTypeFilters") var clearTypesToShow: Set<IIDXClearType>
+    @AppStorage(wrappedValue: [], "ScoresView.DJLevelFilters") var djLevelsToShow: Set<IIDXDJLevel>
+    @AppStorage(wrappedValue: [], "ScoresView.VersionFilters") var versionsToShow: Set<String>
     @AppStorage(wrappedValue: .lastPlayDate, "ScoresView.SortOrder") var sortMode: SortMode
     @AppStorage(wrappedValue: .descending, "ScoresView.SortDirection") var sortOrder: SortOrder
 
@@ -45,13 +45,21 @@ struct ScoresView: View {
 
     @Namespace var scoresNamespace
 
+    var effectiveLevel: IIDXLevel {
+        levelsToShow.count == 1 ? levelsToShow.first! : .all
+    }
+
+    var effectiveDifficulty: IIDXDifficulty {
+        difficultiesToShow.count == 1 ? difficultiesToShow.first! : .all
+    }
+
     var conditionsForReload: [String] {
         [isShowingOnlyPlayDataWithScores.description,
-         String(difficultyToShow.rawValue),
-         levelToShow.rawValue,
-         clearTypeToShow.rawValue,
-         djLevelToShow.rawValue,
-         versionToShow,
+         difficultiesToShow.map { String($0.rawValue) }.sorted().joined(separator: ","),
+         levelsToShow.map { $0.rawValue }.sorted().joined(separator: ","),
+         clearTypesToShow.map { $0.rawValue }.sorted().joined(separator: ","),
+         djLevelsToShow.map { $0.rawValue }.sorted().joined(separator: ","),
+         versionsToShow.sorted().joined(separator: ","),
          sortMode.rawValue,
          sortOrder.rawValue]
     }
@@ -71,9 +79,11 @@ struct ScoresView: View {
                         ScoreRow(
                             namespace: scoresNamespace,
                             songRecord: songRecord,
-                            scoreRate: scoreRate(for: songRecord, of: levelToShow, or: difficultyToShow),
-                            levelToShow: $levelToShow,
-                            difficultyToShow: $difficultyToShow
+                            scoreRate: scoreRate(for: songRecord,
+                                                 of: effectiveLevel,
+                                                 or: effectiveDifficulty),
+                            levelToShow: effectiveLevel,
+                            difficultyToShow: effectiveDifficulty
                         )
                     }
                     .listRowInsets(.init(top: 0.0, leading: 0.0, bottom: 0.0, trailing: 0.0))
@@ -124,11 +134,11 @@ struct ScoresView: View {
                     } else {
                         ScoreSortAndFilter(
                             isShowingOnlyPlayDataWithScores: $isShowingOnlyPlayDataWithScores,
-                            difficultyToShow: $difficultyToShow.animation(.snappy.speed(2.0)),
-                            levelToShow: $levelToShow.animation(.snappy.speed(2.0)),
-                            clearTypeToShow: $clearTypeToShow.animation(.snappy.speed(2.0)),
-                            djLevelToShow: $djLevelToShow.animation(.snappy.speed(2.0)),
-                            versionToShow: $versionToShow.animation(.snappy.speed(2.0)),
+                            difficultiesToShow: $difficultiesToShow.animation(.snappy.speed(2.0)),
+                            levelsToShow: $levelsToShow.animation(.snappy.speed(2.0)),
+                            clearTypesToShow: $clearTypesToShow.animation(.snappy.speed(2.0)),
+                            djLevelsToShow: $djLevelsToShow.animation(.snappy.speed(2.0)),
+                            versionsToShow: $versionsToShow.animation(.snappy.speed(2.0)),
                             sortMode: $sortMode.animation(.snappy.speed(2.0)),
                             sortOrder: $sortOrder.animation(.snappy.speed(2.0)),
                             isSystemChangingFilterAndSort: $isSystemChangingFilterAndSort
@@ -226,7 +236,7 @@ struct ScoresView: View {
                 switch viewPath {
                 case .scoreViewer(let songRecord):
                     ScoreViewer(songRecord: songRecord, noteCount: noteCount,
-                                initialLevel: songRecord.level(for: levelToShow, or: difficultyToShow))
+                                initialLevel: songRecord.level(for: effectiveLevel, or: effectiveDifficulty))
                     .automaticNavigationTransition(id: songRecord.title, in: scoresNamespace)
                 case .scoreHistory(let songTitle, let level, let noteCount):
                     ScoreHistoryViewer(songTitle: songTitle, level: level, noteCount: noteCount)

--- a/DJDX/Views/Scores/ScoresView.swift
+++ b/DJDX/Views/Scores/ScoresView.swift
@@ -55,7 +55,7 @@ struct ScoresView: View {
         difficultiesToShow.count == 1 ? difficultiesToShow.first! : .all
     }
 
-    private static let allLevels: [(IIDXLevel, KeyPath<IIDXSongRecord, IIDXLevelScore>)] = [
+    static let allLevels: [(IIDXLevel, KeyPath<IIDXSongRecord, IIDXLevelScore>)] = [
         (.beginner, \.beginnerScore),
         (.normal, \.normalScore),
         (.hyper, \.hyperScore),

--- a/DJDX/Views/Shared/IIDXLevelShowcase.swift
+++ b/DJDX/Views/Shared/IIDXLevelShowcase.swift
@@ -12,27 +12,37 @@ struct IIDXLevelShowcase: View {
     @AppStorage(wrappedValue: false, "ScoresView.BeginnerLevelHidden") var isBeginnerLevelHidden: Bool
 
     var songRecord: IIDXSongRecord
+    var visibleLevels: Set<IIDXLevel>
+
+    private func isVisible(_ level: IIDXLevel) -> Bool {
+        visibleLevels.isEmpty || visibleLevels.contains(level)
+    }
 
     var body: some View {
         HStack(alignment: .top) {
-            if !isBeginnerLevelHidden,
+            if isVisible(.beginner),
+               !isBeginnerLevelHidden,
                songRecord.beginnerScore.difficulty != 0 {
                 IIDXLevelLabel(levelType: .beginner,
                                score: songRecord.beginnerScore)
             }
-            if songRecord.normalScore.difficulty != 0 {
+            if isVisible(.normal),
+               songRecord.normalScore.difficulty != 0 {
                 IIDXLevelLabel(levelType: .normal,
                                  score: songRecord.normalScore)
             }
-            if songRecord.hyperScore.difficulty != 0 {
+            if isVisible(.hyper),
+               songRecord.hyperScore.difficulty != 0 {
                 IIDXLevelLabel(levelType: .hyper,
                                  score: songRecord.hyperScore)
             }
-            if songRecord.anotherScore.difficulty != 0 {
+            if isVisible(.another),
+               songRecord.anotherScore.difficulty != 0 {
                 IIDXLevelLabel(levelType: .another,
                                  score: songRecord.anotherScore)
             }
-            if songRecord.leggendariaScore.difficulty != 0 {
+            if isVisible(.leggendaria),
+               songRecord.leggendariaScore.difficulty != 0 {
                 IIDXLevelLabel(levelType: .leggendaria,
                                  score: songRecord.leggendariaScore)
             }

--- a/DJDX/Views/Shared/RadarChartView.swift
+++ b/DJDX/Views/Shared/RadarChartView.swift
@@ -13,8 +13,8 @@ struct RadarChartView: View {
     let maxValue: Double = 130.0
     let benchmarkValue: Double = 100.0
 
-    init(_ data: RadarData) {
-        self.color = data.color()
+    init(_ data: RadarData, isPlayerRadar: Bool = false) {
+        self.color = data.color(isPlayerRadar: isPlayerRadar)
         self.points = data.points()
     }
 

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -13,6 +13,17 @@
     "%lld" : {
       "shouldTranslate" : false
     },
+    "%lld %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld %2$@"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
     "A" : {
       "localizations" : {
         "en" : {
@@ -692,22 +703,6 @@
         }
       }
     },
-    "Analytics.Settings.Title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Analytics View"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プレー分析画面を編集"
-          }
-        }
-      }
-    },
     "Analytics.Settings.Cards" : {
       "localizations" : {
         "en" : {
@@ -803,6 +798,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "リセット"
+          }
+        }
+      }
+    },
+    "Analytics.Settings.Title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Analytics View"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレー分析画面を編集"
           }
         }
       }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -658,6 +658,23 @@
         }
       }
     },
+    "Analytics.PerLevel.ClearTypeTrend" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Lamp Trend"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリアランプ推移"
+          }
+        }
+      }
+    },
     "Analytics.PerLevel.DJLevelTrend" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -2148,6 +2148,91 @@
         }
       }
     },
+    "Shared.Filter.Count.ClearTypes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "clear types"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        }
+      }
+    },
+    "Shared.Filter.Count.Difficulties" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "difficulties"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        }
+      }
+    },
+    "Shared.Filter.Count.DJLevels" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DJ levels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        }
+      }
+    },
+    "Shared.Filter.Count.Levels" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "levels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        }
+      }
+    },
+    "Shared.Filter.Count.Versions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "versions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        }
+      }
+    },
     "Shared.Filter.ResetAll" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Widgets/Charts/WidgetRadarChartView.swift
+++ b/Widgets/Charts/WidgetRadarChartView.swift
@@ -49,7 +49,8 @@ struct WidgetRadarChartView: View {
 
     private var color: Color {
         let sum = data.sum
-        if sum > 600.0 { return .purple
+        if sum > 800.0 { return .green
+        } else if sum > 600.0 { return .purple
         } else if sum > 400.0 { return .red
         } else if sum > 200.0 { return .yellow
         } else { return .cyan }


### PR DESCRIPTION
Replace the filter Menu with a sheet presentation using medium/large detents.
The sheet has scrollable content with interactiveDismissDisabled, a confirm
button (Done on iOS 18), and sections for Filters and Display Settings.

https://claude.ai/code/session_019KkjVzNqnwjyFshWQr1y4A