### PR TITLE
Rename filter sheet title to Customize Display and add matched transition

### DIFF
--- a/DJDX/Views/Scores/ScoreSortAndFilter.swift
+++ b/DJDX/Views/Scores/ScoreSortAndFilter.swift
@@ -28,6 +28,7 @@ struct ScoreSortAndFilter: View {
     @AppStorage(wrappedValue: true, "ScoresView.ScoreVisible") var isScoreVisible: Bool
     @AppStorage(wrappedValue: false, "ScoresView.LastPlayDateVisible") var isLastPlayDateVisible: Bool
 
+    @Namespace var filterNamespace
     @State private var isShowingFilterSheet: Bool = false
 
     var body: some View {
@@ -56,6 +57,7 @@ struct ScoreSortAndFilter: View {
         Button("Shared.Filter", systemImage: "line.3.horizontal.decrease") {
             isShowingFilterSheet = true
         }
+        .automaticMatchedTransitionSource(id: "ScoreFilterSheet", in: filterNamespace)
         .sheet(isPresented: $isShowingFilterSheet) {
             ScoreFilterSheet(
                 isShowingOnlyPlayDataWithScores: $isShowingOnlyPlayDataWithScores,
@@ -234,7 +236,7 @@ struct ScoreFilterSheet: View {
                 }
             }
             .listSectionSpacing(.compact)
-            .navigationTitle("Shared.Filter")
+            .navigationTitle("Scores.CustomizeDisplay")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1827,6 +1827,23 @@
         }
       }
     },
+    "Scores.CustomizeDisplay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customize Display"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示をカスタマイズ"
+          }
+        }
+      }
+    },
     "Scores.Filter.ShowWithScoreOnly" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
The filter sheet now opens with a matched geometry transition from the
toolbar button (iOS 18+) and uses a clearer "Customize Display" navigation
title that better reflects the sheet's purpose.

https://claude.ai/code/session_01N77zRumMwMtJ3T7a3SnNWo