### PR TITLE
Improve reliability of WebView login and score import

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.3;
+				MARKETING_VERSION = 33.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.3;
+				MARKETING_VERSION = 33.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.3;
+				MARKETING_VERSION = 33.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.3;
+				MARKETING_VERSION = 33.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DJDX/Views/Shared/WebImporter.swift
+++ b/DJDX/Views/Shared/WebImporter.swift
@@ -151,6 +151,8 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
     var version: IIDXVersion
 
     var hasStartedExtraction: Bool = false
+    var hasResolved: Bool = false
+    var watchdog: Task<Void, Never>?
 
     init(
         delegate: UpdateScoreDataDelegate,
@@ -175,16 +177,29 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
                 self.extractScoreData(from: webView)
             } else if urlString.starts(with: self.version.errorPageURL().absoluteString) {
                 webView.layer.opacity = 0.0
-                let reason = Self.failureReason(forErrorPageURL: urlString)
-                Task {
-                    await MainActor.run {
-                        self.delegate.stopProcessing(with: reason)
-                    }
-                }
+                self.resolveFailure(with: Self.failureReason(forErrorPageURL: urlString))
             } else {
                 webView.layer.opacity = 1.0
             }
         }
+    }
+
+    func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError error: Error) {
+        handleNavigationFailure(error)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
+        handleNavigationFailure(error)
+    }
+
+    // Surfaces a real load failure as an error instead of leaving the user on an endless spinner,
+    // while ignoring the benign cancellations/redirect interruptions that occur during the
+    // multi-step sign-in.
+    func handleNavigationFailure(_ error: Error) {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled { return }
+        if nsError.domain == "WebKitErrorDomain" && nsError.code == 102 { return }
+        resolveFailure(with: .serverError)
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
@@ -199,6 +214,7 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
     }
 
     func extractScoreData(from webView: WKWebView) {
+        startExtractionWatchdog()
         let buttonValue: String
         switch importMode {
         case .single: buttonValue = "SP"
@@ -213,21 +229,47 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
         ) { result in
             switch result {
             case .success(let value): self.handleExtractionResult(value as? String)
-            case .failure: self.handleExtractionResult(nil)
+            case .failure: self.resolveFailure(with: .serverError)
             }
         }
     }
 
     func handleExtractionResult(_ value: String?) {
         guard let value, !value.isEmpty else {
-            Task { await MainActor.run { self.delegate.stopProcessing(with: .serverError) } }
+            resolveFailure(with: .serverError)
             return
         }
         if value.hasPrefix("ERR:") {
-            let reason = Self.failureReason(forSentinel: String(value.dropFirst(4)))
-            Task { await MainActor.run { self.delegate.stopProcessing(with: reason) } }
+            resolveFailure(with: Self.failureReason(forSentinel: String(value.dropFirst(4))))
         } else {
-            Task { await self.delegate.importScoreData(using: value) }
+            resolveSuccess(with: value)
+        }
+    }
+
+    // A single resolution funnel guards against the watchdog, the fetch result and a navigation
+    // failure racing to finish the import more than once.
+    func resolveSuccess(with csvString: String) {
+        guard !hasResolved else { return }
+        hasResolved = true
+        watchdog?.cancel()
+        Task { await self.delegate.importScoreData(using: csvString) }
+    }
+
+    func resolveFailure(with reason: ImportFailedReason) {
+        guard !hasResolved else { return }
+        hasResolved = true
+        watchdog?.cancel()
+        Task { await MainActor.run { self.delegate.stopProcessing(with: reason) } }
+    }
+
+    func startExtractionWatchdog() {
+        watchdog?.cancel()
+        watchdog = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(25))
+            if Task.isCancelled { return }
+            await MainActor.run {
+                self?.resolveFailure(with: .serverError)
+            }
         }
     }
 

--- a/DJDX/Views/Shared/WebImporter.swift
+++ b/DJDX/Views/Shared/WebImporter.swift
@@ -146,54 +146,11 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
 \(loginPageCleanup)
 """
 
-    let selectSPButtonJS = """
-var submitButtons = document.getElementsByClassName('submit_btn')
-if (submitButtons.length > 0) {
-    Array.from(submitButtons).forEach(button => {
-        if (button.value === "SP") {
-            button.click()
-        }
-    })
-} else {
-    throw 1
-}
-"""
-
-    let selectDPButtonJS = """
-var submitButtons = document.getElementsByClassName('submit_btn')
-if (submitButtons.length > 0) {
-    Array.from(submitButtons).forEach(button => {
-        if (button.value === "DP") {
-            button.click()
-        }
-    })
-} else {
-    throw 1
-}
-"""
-
-    let selectTowerButtonJS = """
-var submitButtons = document.getElementsByClassName('submit_btn')
-if (submitButtons.length > 0) {
-    Array.from(submitButtons).forEach(button => {
-        if (button.value === "tower") {
-            button.click()
-        }
-    })
-} else {
-    throw 1
-}
-"""
-
-    let getScoreDataJS = """
-document.getElementById('score_data').value
-"""
-
     var delegate: UpdateScoreDataDelegate
     var importMode: IIDXImportMode
     var version: IIDXVersion
 
-    var waitingForDownloadPageFormSubmit: Bool = false
+    var hasStartedExtraction: Bool = false
 
     init(
         delegate: UpdateScoreDataDelegate,
@@ -206,59 +163,26 @@ document.getElementById('score_data').value
         super.init()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-        if let webViewURL = webView.url {
-            let urlString = webViewURL.absoluteString
-            webView.evaluateJavaScript(self.cleanupJS) { _, _ in
-                if urlString.starts(with: self.version.downloadPageURL().absoluteString) {
-                    webView.layer.opacity = 0.0
-                    webView.isUserInteractionEnabled = false
-                    if !self.waitingForDownloadPageFormSubmit {
-                        switch self.importMode {
-                        case .single: self.evaluateIIDXSPScript(webView)
-                        case .double: self.evaluateIIDXDPScript(webView)
-                        case .tower: self.evaluateTowerScript(webView)
-                        }
-                        self.waitingForDownloadPageFormSubmit = true
-                    } else {
-                        webView.evaluateJavaScript(self.getScoreDataJS) { result, _ in
-                            if let result: String = result as? String {
-                                Task {
-                                    await self.delegate.importScoreData(using: result)
-                                }
-                            } else {
-                                Task {
-                                    await MainActor.run {
-                                        self.delegate.stopProcessing(with: .serverError)
-                                    }
-                                }
-                            }
-                        }
-                        self.waitingForDownloadPageFormSubmit = false
+        guard let webViewURL = webView.url else { return }
+        let urlString = webViewURL.absoluteString
+        webView.evaluateJavaScript(self.cleanupJS) { _, _ in
+            if urlString.starts(with: self.version.downloadPageURL().absoluteString) {
+                webView.layer.opacity = 0.0
+                webView.isUserInteractionEnabled = false
+                guard !self.hasStartedExtraction else { return }
+                self.hasStartedExtraction = true
+                self.extractScoreData(from: webView)
+            } else if urlString.starts(with: self.version.errorPageURL().absoluteString) {
+                webView.layer.opacity = 0.0
+                let reason = Self.failureReason(forErrorPageURL: urlString)
+                Task {
+                    await MainActor.run {
+                        self.delegate.stopProcessing(with: reason)
                     }
-                } else if urlString.starts(with: self.version.errorPageURL().absoluteString) {
-                    webView.layer.opacity = 0.0
-                    Task { [urlString] in
-                        await MainActor.run {
-                            if urlString.hasSuffix("?err=1") {
-                                self.delegate.stopProcessing(with: .noPremiumCourse)
-                            } else if urlString.hasSuffix("?err=2") {
-                                self.delegate.stopProcessing(with: .noEAmusementPass)
-                            } else if urlString.hasSuffix("?err=3") {
-                                self.delegate.stopProcessing(with: .noPlayData)
-                            } else if urlString.hasSuffix("?err=4") {
-                                self.delegate.stopProcessing(with: .serverError)
-                            } else if urlString.hasSuffix("?err=5") {
-                                self.delegate.stopProcessing(with: .noPremiumCourse)
-                            } else {
-                                self.delegate.stopProcessing(with: .serverError)
-                            }
-                        }
-                    }
-                } else {
-                    webView.layer.opacity = 1.0
                 }
+            } else {
+                webView.layer.opacity = 1.0
             }
         }
     }
@@ -274,28 +198,54 @@ document.getElementById('score_data').value
         }
     }
 
-    func evaluateIIDXSPScript(_ webView: WKWebView) {
-        webView.evaluateJavaScript(self.selectSPButtonJS) { _, error in
-            if error != nil {
-                self.delegate.stopProcessing(with: .maintenance)
+    func extractScoreData(from webView: WKWebView) {
+        let buttonValue: String
+        switch importMode {
+        case .single: buttonValue = "SP"
+        case .double: buttonValue = "DP"
+        case .tower: buttonValue = "tower"
+        }
+        webView.callAsyncJavaScript(
+            scoreDownloadFetchBody,
+            arguments: ["buttonValue": buttonValue],
+            in: nil,
+            in: .page
+        ) { result in
+            switch result {
+            case .success(let value): self.handleExtractionResult(value as? String)
+            case .failure: self.handleExtractionResult(nil)
             }
         }
     }
 
-    func evaluateIIDXDPScript(_ webView: WKWebView) {
-        webView.evaluateJavaScript(self.selectDPButtonJS) { _, error in
-            if error != nil {
-                self.delegate.stopProcessing(with: .maintenance)
-            }
+    func handleExtractionResult(_ value: String?) {
+        guard let value, !value.isEmpty else {
+            Task { await MainActor.run { self.delegate.stopProcessing(with: .serverError) } }
+            return
+        }
+        if value.hasPrefix("ERR:") {
+            let reason = Self.failureReason(forSentinel: String(value.dropFirst(4)))
+            Task { await MainActor.run { self.delegate.stopProcessing(with: reason) } }
+        } else {
+            Task { await self.delegate.importScoreData(using: value) }
         }
     }
 
-    func evaluateTowerScript(_ webView: WKWebView) {
-        webView.evaluateJavaScript(self.selectTowerButtonJS) { _, error in
-            if error != nil {
-                self.delegate.stopProcessing(with: .maintenance)
-            }
+    static func failureReason(forSentinel sentinel: String) -> ImportFailedReason {
+        switch sentinel {
+        case "1", "5": return .noPremiumCourse
+        case "2": return .noEAmusementPass
+        case "3": return .noPlayData
+        case "maintenance": return .maintenance
+        default: return .serverError
         }
+    }
+
+    static func failureReason(forErrorPageURL urlString: String) -> ImportFailedReason {
+        if let range = urlString.range(of: "err=") {
+            return failureReason(forSentinel: String(urlString[range.upperBound...]))
+        }
+        return .serverError
     }
 }
 

--- a/DJDX/Views/Shared/WebImporter.swift
+++ b/DJDX/Views/Shared/WebImporter.swift
@@ -70,6 +70,11 @@ struct WebViewForImporter: UIViewRepresentable, @preconcurrency UpdateScoreDataD
                          injectionTime: .atDocumentStart,
                          forMainFrameOnly: false)
         )
+        contentController.addUserScript(
+            WKUserScript(source: otpAutofillUserScript,
+                         injectionTime: .atDocumentStart,
+                         forMainFrameOnly: false)
+        )
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = contentController
         return WKWebView(frame: .zero, configuration: configuration)

--- a/DJDX/Views/Shared/WebImporter.swift
+++ b/DJDX/Views/Shared/WebImporter.swift
@@ -63,7 +63,17 @@ struct WebViewForImporter: UIViewRepresentable, @preconcurrency UpdateScoreDataD
 
     @AppStorage(wrappedValue: IIDXVersion.sparkleShower, "Global.IIDX.Version") var iidxVersion: IIDXVersion
 
-    let webView = WKWebView()
+    let webView: WKWebView = {
+        let contentController = WKUserContentController()
+        contentController.addUserScript(
+            WKUserScript(source: loginPageDarkModeUserScript,
+                         injectionTime: .atDocumentStart,
+                         forMainFrameOnly: false)
+        )
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = contentController
+        return WKWebView(frame: .zero, configuration: configuration)
+    }()
 
     func makeUIView(context: Context) -> WKWebView {
         webView.navigationDelegate = context.coordinator

--- a/DJDX/Views/Shared/WebImporter.swift
+++ b/DJDX/Views/Shared/WebImporter.swift
@@ -192,9 +192,6 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
         handleNavigationFailure(error)
     }
 
-    // Surfaces a real load failure as an error instead of leaving the user on an endless spinner,
-    // while ignoring the benign cancellations/redirect interruptions that occur during the
-    // multi-step sign-in.
     func handleNavigationFailure(_ error: Error) {
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled { return }
@@ -246,8 +243,6 @@ class CoordinatorForImporter: NSObject, WKNavigationDelegate {
         }
     }
 
-    // A single resolution funnel guards against the watchdog, the fetch result and a navigation
-    // failure racing to finish the import more than once.
     func resolveSuccess(with csvString: String) {
         guard !hasResolved else { return }
         hasResolved = true

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -244,6 +244,68 @@ let otpAutofillUserScript = """
 })();
 """
 
+// Body for callAsyncJavaScript. Faithfully reconstructs the score_download form submission
+// (carrying every named field, including any CSRF/hidden tokens, plus the chosen SP/DP/tower
+// button) via a same-origin fetch, then returns the score_data CSV from the response. The
+// browser owns cookies, CSRF and text decoding, so this avoids the previous two-navigation
+// state machine. Returns an "ERR:<code>" sentinel for the e-amusement error page (?err=N),
+// "ERR:maintenance" when the buttons are missing, or "ERR:empty" when no score data is present.
+let scoreDownloadFetchBody = """
+const buttons = Array.from(document.getElementsByClassName('submit_btn'));
+const button = buttons.find(function(candidate) { return candidate.value === buttonValue; });
+if (!button) { return 'ERR:maintenance'; }
+const form = button.form || button.closest('form');
+if (!form) { return 'ERR:maintenance'; }
+
+const params = new URLSearchParams();
+Array.from(form.elements).forEach(function(element) {
+    if (!element.name) { return; }
+    const type = (element.type || '').toLowerCase();
+    if (type === 'submit' || type === 'button' || type === 'reset' || type === 'file') { return; }
+    if ((type === 'checkbox' || type === 'radio') && !element.checked) { return; }
+    params.append(element.name, element.value);
+});
+if (button.name) { params.append(button.name, button.value); }
+
+const action = form.getAttribute('action');
+const targetURL = action ? new URL(action, document.baseURI).href : location.href;
+const method = (form.getAttribute('method') || 'POST').toUpperCase();
+
+let response;
+if (method === 'GET') {
+    const joiner = targetURL.indexOf('?') === -1 ? '?' : '&';
+    response = await fetch(targetURL + joiner + params.toString(), {
+        method: 'GET',
+        credentials: 'same-origin'
+    });
+} else {
+    response = await fetch(targetURL, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString()
+    });
+}
+
+const finalURL = response.url || '';
+if (finalURL.indexOf('/error/error.html') !== -1) {
+    const match = finalURL.match(/[?&]err=([0-9]+)/);
+    return 'ERR:' + (match ? match[1] : 'server');
+}
+
+const html = await response.text();
+const parsed = new DOMParser().parseFromString(html, 'text/html');
+const node = parsed.getElementById('score_data');
+if (node) {
+    const value = (node.value !== undefined && node.value !== null && node.value !== '')
+        ? node.value
+        : (node.getAttribute('value') || node.textContent || '');
+    if (value && value.length > 0) { return value; }
+}
+if (html.indexOf('/error/error.html') !== -1) { return 'ERR:server'; }
+return 'ERR:empty';
+"""
+
 let iidxTowerCleanup = """
 var injectedCSS = `
 #base {

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -109,7 +109,8 @@ let loginPageDarkModeUserScript = """
     .card,
     .accordion-item,
     .accordion-button,
-    .bg-light,
+    body .bg-light,
+    body .bg-white,
     #email-form {
         border-color: #46464a !important;
         background-color: #1c1c1e !important;

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -87,9 +87,6 @@ waitForElementToExist('#page-top').then((element) => {
 })
 """
 
-// Injected at document start so the theme is present before first paint and persists
-// across the login SPA's re-renders. Selectors are intentionally broad/structural because
-// KONAMI's CSS-module class names carry hashes that drift between deployments.
 let loginPageDarkModeUserScript = """
 (function() {
     var darkModeCSS = `
@@ -157,11 +154,6 @@ waitForElementToExist('.fs-6').then((element) => {
 })
 """
 
-// Injected at document start. iOS keyboard autofill of a one-time code drops the whole
-// code into the first box of a split OTP input (each box has maxlength="1"), so only the
-// first digit survives truncation. This intercepts the multi-character insertion and
-// distributes the digits across the boxes, dispatching native events so the SPA registers
-// each one. Selectors must be validated against the live 2FA DOM.
 let otpAutofillUserScript = """
 (function() {
     function isOtpBox(el) {
@@ -244,12 +236,6 @@ let otpAutofillUserScript = """
 })();
 """
 
-// Body for callAsyncJavaScript. Faithfully reconstructs the score_download form submission
-// (carrying every named field, including any CSRF/hidden tokens, plus the chosen SP/DP/tower
-// button) via a same-origin fetch, then returns the score_data CSV from the response. The
-// browser owns cookies, CSRF and text decoding, so this avoids the previous two-navigation
-// state machine. Returns an "ERR:<code>" sentinel for the e-amusement error page (?err=N),
-// "ERR:maintenance" when the buttons are missing, or "ERR:empty" when no score data is present.
 let scoreDownloadFetchBody = """
 async function fetchScoreData() {
     const buttons = Array.from(document.getElementsByClassName('submit_btn'));
@@ -307,7 +293,6 @@ async function fetchScoreData() {
     return 'ERR:empty';
 }
 
-// Retry only transient network failures (a thrown fetch); definitive sentinels return as-is.
 for (let attempt = 0; attempt < 3; attempt++) {
     try {
         return await fetchScoreData();

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -87,42 +87,52 @@ waitForElementToExist('#page-top').then((element) => {
 })
 """
 
-let loginPageCleanup = """
-// ダークモード
-var darkModeCSS = `
+// Injected at document start so the theme is present before first paint and persists
+// across the login SPA's re-renders. Selectors are intentionally broad/structural because
+// KONAMI's CSS-module class names carry hashes that drift between deployments.
+let loginPageDarkModeUserScript = """
+(function() {
+    var darkModeCSS = `
 @media (prefers-color-scheme: dark) {
-    body, #id_ea_common_content_whole {
-        background-color: #000000;
-        color: #ffffff;
+    html, body, #id_ea_common_content_whole, #base, #base-inner, main, [class*="Layout"] {
+        background-color: #000000 !important;
+        color: #ffffff !important;
     }
     header,
+    [class*="Header"],
     [class*="Header_logo__konami--default"] {
-        background-color: #000000!important;
+        background-color: #000000 !important;
     }
-    [class*="Form_login__layout--narrow-frame"],
-    [class*="Form_login__layout--default"],
-    [class*="Form_login__form--default"],
-    [class*="Form_login__form--narrow-frame"],
+    [class*="Form_login__layout"],
+    [class*="Form_login__form"],
+    [class*="Card"],
+    .card,
     #email-form {
-        border: unset;
-        background-color: #1c1c1e!important;
+        border: unset !important;
+        background-color: #1c1c1e !important;
     }
+    label,
     .form-floating > label {
-      color: #aaa;
+        color: #aaaaaa !important;
     }
     .form-floating > .form-control:focus ~ label {
-      color: #eee;
+        color: #eeeeee !important;
     }
     .m-icon--arrow_back_back {
         filter: invert();
         opacity: 40%;
     }
-    .form-control, .form-control:focus {
-        background-color: #000000!important;
-        color: #fff!important;
+    input,
+    textarea,
+    select,
+    .form-control,
+    .form-control:focus {
+        background-color: #000000 !important;
+        color: #ffffff !important;
+        border-color: #46464a !important;
     }
-    .card {
-        background-color: #1c1c1e!important;
+    a {
+        color: #4da3ff !important;
     }
 }
 
@@ -132,15 +142,19 @@ var darkModeCSS = `
         color: #000000;
     }
 }
-`
-style.appendChild(document.createTextNode(darkModeCSS))
-head.appendChild(style)
+`;
+    var style = document.createElement('style');
+    style.type = 'text/css';
+    style.textContent = darkModeCSS;
+    (document.head || document.documentElement).appendChild(style);
+})();
+"""
 
+let loginPageCleanup = """
 // チャットポップアップを取り除く
 waitForElementToExist('.fs-6').then((element) => {
     document.getElementsByClassName('fs-6')[0].remove()
 })
-
 """
 
 let iidxTowerCleanup = """

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -157,6 +157,93 @@ waitForElementToExist('.fs-6').then((element) => {
 })
 """
 
+// Injected at document start. iOS keyboard autofill of a one-time code drops the whole
+// code into the first box of a split OTP input (each box has maxlength="1"), so only the
+// first digit survives truncation. This intercepts the multi-character insertion and
+// distributes the digits across the boxes, dispatching native events so the SPA registers
+// each one. Selectors must be validated against the live 2FA DOM.
+let otpAutofillUserScript = """
+(function() {
+    function isOtpBox(el) {
+        if (!el || el.tagName !== 'INPUT') { return false; }
+        var type = (el.getAttribute('type') || 'text').toLowerCase();
+        if (type !== 'text' && type !== 'tel' && type !== 'number') { return false; }
+        var autocomplete = (el.getAttribute('autocomplete') || '').toLowerCase();
+        if (autocomplete.indexOf('one-time-code') !== -1) { return true; }
+        var maxLength = el.getAttribute('maxlength');
+        var inputmode = (el.getAttribute('inputmode') || '').toLowerCase();
+        var pattern = el.getAttribute('pattern') || '';
+        var numericish = inputmode === 'numeric' || inputmode === 'tel'
+            || pattern.indexOf('0-9') !== -1 || type === 'tel' || type === 'number';
+        return maxLength === '1' && numericish;
+    }
+
+    function otpBoxes(target) {
+        var scope = target.form || target.closest('form') || document;
+        var boxes = Array.prototype.slice.call(scope.querySelectorAll('input')).filter(isOtpBox);
+        if (boxes.indexOf(target) === -1 && isOtpBox(target)) { boxes.push(target); }
+        return boxes;
+    }
+
+    function setValue(el, value) {
+        var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(el, value);
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    function distribute(boxes, startIndex, data) {
+        var chars = (data || '').replace(/\\s/g, '').split('');
+        var count = 0;
+        for (var i = 0; i < chars.length && (startIndex + i) < boxes.length; i++) {
+            setValue(boxes[startIndex + i], chars[i]);
+            count++;
+        }
+        var lastIndex = startIndex + count - 1;
+        if (lastIndex >= 0 && boxes[lastIndex]) { boxes[lastIndex].focus(); }
+    }
+
+    function indexOfTarget(boxes, target) {
+        var index = boxes.indexOf(target);
+        return index === -1 ? 0 : index;
+    }
+
+    document.addEventListener('beforeinput', function(event) {
+        var target = event.target;
+        if (!isOtpBox(target)) { return; }
+        var data = event.data;
+        if (data && data.length > 1) {
+            var boxes = otpBoxes(target);
+            event.preventDefault();
+            distribute(boxes, indexOfTarget(boxes, target), data);
+        }
+    }, true);
+
+    document.addEventListener('input', function(event) {
+        var target = event.target;
+        if (!isOtpBox(target)) { return; }
+        if (target.value && target.value.length > 1) {
+            var boxes = otpBoxes(target);
+            var data = target.value;
+            setValue(target, '');
+            distribute(boxes, indexOfTarget(boxes, target), data);
+        }
+    }, true);
+
+    document.addEventListener('paste', function(event) {
+        var target = event.target;
+        if (!isOtpBox(target)) { return; }
+        var clipboard = event.clipboardData || window.clipboardData;
+        var text = clipboard ? clipboard.getData('text') : '';
+        if (text && text.length > 1) {
+            var boxes = otpBoxes(target);
+            event.preventDefault();
+            distribute(boxes, indexOfTarget(boxes, target), text);
+        }
+    }, true);
+})();
+"""
+
 let iidxTowerCleanup = """
 var injectedCSS = `
 #base {

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -91,24 +91,35 @@ let loginPageDarkModeUserScript = """
 (function() {
     var darkModeCSS = `
 @media (prefers-color-scheme: dark) {
-    html, body, #id_ea_common_content_whole, #base, #base-inner, main, [class*="Layout"] {
+    html, body,
+    main,
+    [class*="Layout"],
+    #id_ea_common_content_whole, #base, #base-inner {
         background-color: #000000 !important;
         color: #ffffff !important;
     }
     header,
+    footer,
     [class*="Header"],
-    [class*="Header_logo__konami--default"] {
+    [class*="Footer"] {
         background-color: #000000 !important;
+        color: #ffffff !important;
     }
-    [class*="Form_login__layout"],
-    [class*="Form_login__form"],
-    [class*="Card"],
+    [class*="login__"],
     .card,
+    .accordion-item,
+    .accordion-button,
+    .bg-light,
     #email-form {
-        border: unset !important;
+        border-color: #46464a !important;
         background-color: #1c1c1e !important;
+        color: #ffffff !important;
     }
-    label,
+    h1, h2, h3, h4, h5, h6,
+    p, span, summary, label,
+    .nav-link {
+        color: #ffffff !important;
+    }
     .form-floating > label {
         color: #aaaaaa !important;
     }
@@ -128,7 +139,7 @@ let loginPageDarkModeUserScript = """
         color: #ffffff !important;
         border-color: #46464a !important;
     }
-    a {
+    a, .link-primary {
         color: #4da3ff !important;
     }
 }

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -251,59 +251,72 @@ let otpAutofillUserScript = """
 // state machine. Returns an "ERR:<code>" sentinel for the e-amusement error page (?err=N),
 // "ERR:maintenance" when the buttons are missing, or "ERR:empty" when no score data is present.
 let scoreDownloadFetchBody = """
-const buttons = Array.from(document.getElementsByClassName('submit_btn'));
-const button = buttons.find(function(candidate) { return candidate.value === buttonValue; });
-if (!button) { return 'ERR:maintenance'; }
-const form = button.form || button.closest('form');
-if (!form) { return 'ERR:maintenance'; }
+async function fetchScoreData() {
+    const buttons = Array.from(document.getElementsByClassName('submit_btn'));
+    const button = buttons.find(function(candidate) { return candidate.value === buttonValue; });
+    if (!button) { return 'ERR:maintenance'; }
+    const form = button.form || button.closest('form');
+    if (!form) { return 'ERR:maintenance'; }
 
-const params = new URLSearchParams();
-Array.from(form.elements).forEach(function(element) {
-    if (!element.name) { return; }
-    const type = (element.type || '').toLowerCase();
-    if (type === 'submit' || type === 'button' || type === 'reset' || type === 'file') { return; }
-    if ((type === 'checkbox' || type === 'radio') && !element.checked) { return; }
-    params.append(element.name, element.value);
-});
-if (button.name) { params.append(button.name, button.value); }
-
-const action = form.getAttribute('action');
-const targetURL = action ? new URL(action, document.baseURI).href : location.href;
-const method = (form.getAttribute('method') || 'POST').toUpperCase();
-
-let response;
-if (method === 'GET') {
-    const joiner = targetURL.indexOf('?') === -1 ? '?' : '&';
-    response = await fetch(targetURL + joiner + params.toString(), {
-        method: 'GET',
-        credentials: 'same-origin'
+    const params = new URLSearchParams();
+    Array.from(form.elements).forEach(function(element) {
+        if (!element.name) { return; }
+        const type = (element.type || '').toLowerCase();
+        if (type === 'submit' || type === 'button' || type === 'reset' || type === 'file') { return; }
+        if ((type === 'checkbox' || type === 'radio') && !element.checked) { return; }
+        params.append(element.name, element.value);
     });
-} else {
-    response = await fetch(targetURL, {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: params.toString()
-    });
+    if (button.name) { params.append(button.name, button.value); }
+
+    const action = form.getAttribute('action');
+    const targetURL = action ? new URL(action, document.baseURI).href : location.href;
+    const method = (form.getAttribute('method') || 'POST').toUpperCase();
+
+    let response;
+    if (method === 'GET') {
+        const joiner = targetURL.indexOf('?') === -1 ? '?' : '&';
+        response = await fetch(targetURL + joiner + params.toString(), {
+            method: 'GET',
+            credentials: 'same-origin'
+        });
+    } else {
+        response = await fetch(targetURL, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString()
+        });
+    }
+
+    const finalURL = response.url || '';
+    if (finalURL.indexOf('/error/error.html') !== -1) {
+        const match = finalURL.match(/[?&]err=([0-9]+)/);
+        return 'ERR:' + (match ? match[1] : 'server');
+    }
+
+    const html = await response.text();
+    const parsed = new DOMParser().parseFromString(html, 'text/html');
+    const node = parsed.getElementById('score_data');
+    if (node) {
+        const value = (node.value !== undefined && node.value !== null && node.value !== '')
+            ? node.value
+            : (node.getAttribute('value') || node.textContent || '');
+        if (value && value.length > 0) { return value; }
+    }
+    if (html.indexOf('/error/error.html') !== -1) { return 'ERR:server'; }
+    return 'ERR:empty';
 }
 
-const finalURL = response.url || '';
-if (finalURL.indexOf('/error/error.html') !== -1) {
-    const match = finalURL.match(/[?&]err=([0-9]+)/);
-    return 'ERR:' + (match ? match[1] : 'server');
+// Retry only transient network failures (a thrown fetch); definitive sentinels return as-is.
+for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+        return await fetchScoreData();
+    } catch (error) {
+        if (attempt === 2) { return 'ERR:network'; }
+        await new Promise(function(resolve) { setTimeout(resolve, 600 * (attempt + 1)); });
+    }
 }
-
-const html = await response.text();
-const parsed = new DOMParser().parseFromString(html, 'text/html');
-const node = parsed.getElementById('score_data');
-if (node) {
-    const value = (node.value !== undefined && node.value !== null && node.value !== '')
-        ? node.value
-        : (node.getAttribute('value') || node.textContent || '');
-    if (value && value.length > 0) { return value; }
-}
-if (html.indexOf('/error/error.html') !== -1) { return 'ERR:server'; }
-return 'ERR:empty';
+return 'ERR:network';
 """
 
 let iidxTowerCleanup = """


### PR DESCRIPTION
## Summary

Keeps the visible KONAMI web sign-in (credentials / CAPTCHA / 2FA stay on KONAMI's real page) but makes theming, 2FA entry and the post-login score loading far more reliable. The score extraction now runs in the background via injected JS instead of a fragile multi-navigation WebView scrape.

Each commit is one self-contained workstream:

1. **Dark mode** — moves the login-page dark mode CSS out of the reactive `didFinish` cleanup into a `WKUserScript` injected at `.atDocumentStart`, so it applies before first paint and persists across the login SPA's re-renders. Selectors were broadened to structural ones because the CSS-module class names carry hashes that drift between deployments, which previously left some components unthemed.
2. **2FA autofill** — adds a document-start shim that intercepts a full one-time code autofilled into the first of KONAMI's split single-character OTP boxes (where `maxlength="1"` truncated it to one digit) and distributes the digits across the boxes, dispatching native `input`/`change` events so the SPA registers each one.
3. **Background extraction** — replaces the two-navigation state machine (click submit, wait for reload, scrape `#score_data` on the second `didFinish`) with one `callAsyncJavaScript` that faithfully reconstructs the `score_download` form POST via a same-origin `fetch` (carrying every named field, including CSRF/hidden tokens) and returns the CSV directly. The browser keeps owning cookies, CSRF and text decoding, so Japanese song titles decode correctly. Error pages (`?err=N`) map to the existing `ImportFailedReason` cases.
4. **Hardening** — adds `didFail`/`didFailProvisionalNavigation` handling (ignoring benign cancellations and redirect interruptions), a watchdog that surfaces an error if the background extraction stalls (instead of an endless spinner), and a bounded fetch retry on transient network failures, all behind a single resolution funnel so the watchdog/result/failure can't finish the import twice.

The existing cookie sync (`didCommit`), `DataImporter.importCSV`, and the `isAutoImportFailed` / `autoImportFailedReason` alert plumbing are reused unchanged. No native credential handling was added.

## Files changed
- `Shared/JavaScript.swift` — dark mode document-start script, OTP distribution shim, and the `fetch`-based extraction body with retry.
- `DJDX/Views/Shared/WebImporter.swift` — `WKWebViewConfiguration` + user scripts, rewritten extraction, navigation-failure/watchdog/resolution logic.

## Risks / must verify on device (real e-amusement account)
These could not be validated in CI and need on-device testing on macOS/simulator:
- **Page charset** of `score_download.html` — confirm Japanese song titles import correctly end-to-end (the existing `downloadStatusPageData()` decodes the sibling status page as UTF-8, which is the encouraging precedent).
- **Form action/method** — the JS reads `form.action`/`form.method` dynamically; confirm SP/DP submit to the form itself and whether Tower diverges.
- **Exact OTP DOM** (box count, `maxlength`, React-controlled) — validate the shim's selectors against the live 2FA page.
- **Dark-mode selectors** — confirm no light-on-light components remain after the document-start injection.

## Test plan
- [ ] Login page renders fully themed in light and dark mode (form, inputs, cards, header, buttons), no flash of unthemed content.
- [ ] 2FA: keyboard autofill of the one-time code populates all boxes and submit succeeds.
- [ ] Import SP, DP, and Tower; scores import and Japanese titles are correct.
- [ ] Failure paths: no premium course / no e-amusement pass / no play data / maintenance each show the correct localized error alert (not an infinite spinner).
- [ ] Network drop mid-flow (Airplane Mode) surfaces an error via the watchdog/`didFail` and recovers on retry.
- [ ] SwiftLint passes on the changed files.

https://claude.ai/code/session_01XBFCCoZPBTw4XbSE4odtHM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBFCCoZPBTw4XbSE4odtHM)_