### PR TITLE
Bump version to 33.2.5 and fix Textage WebView

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from 33.2.4 to 33.2.5 across all targets.
- Fix the Textage chart WebView (`TextageViewer` / `textageNavigationJS`), which stopped jumping to charts after the previous merge (#80).

## Status

- [x] Version bump to 33.2.5
- [ ] Textage WebView fix — in progress (verifying how `do_djauto()` on `textage.cc/score/index.html` reads the `djauto` field and builds the chart URL before correcting `textageNavigationJS`)

The Textage fix will land as an additional commit on this branch.

https://claude.ai/code/session_015W6a9GrB2uopu2HR6mKq5n

---
_Generated by [Claude Code](https://claude.ai/code/session_015W6a9GrB2uopu2HR6mKq5n)_