### PR TITLE
Bump version to 33.2.5 and fix stuck Textage viewer

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.2.4;
+				MARKETING_VERSION = 33.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DJDX/Views/Scores/TextageViewer.swift
+++ b/DJDX/Views/Scores/TextageViewer.swift
@@ -170,12 +170,20 @@ struct WebViewForTextage: UIViewRepresentable {
                     webView.evaluateJavaScript(
                         textageNavigationJS
                             .replacingOccurrences(of: "%@1", with: levelValue())
-                            .replacingOccurrences(of: "%@2", with: songTitle)
+                            .replacingOccurrences(of: "%@2", with: escapedForJavaScript(songTitle))
                     )
                 } else {
                     self.updateTextageState(true)
                 }
             }
+        }
+
+        func escapedForJavaScript(_ string: String) -> String {
+            string
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
         }
 
         // swiftlint: disable cyclomatic_complexity

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -389,11 +389,28 @@ head.appendChild(style)
 """
 
 let textageNavigationJS = """
-var levelSelectors = document.getElementsByName("djauto_opt")[0];
-levelSelectors.value = "%@1";
+(function() {
+    var levelSelector = document.getElementsByName("djauto_opt")[0];
+    var songNameTextField = document.getElementsByName("djauto")[0];
+    if (!levelSelector || !songNameTextField) { return; }
 
-var songNameTextField = document.getElementsByName("djauto")[0];
-songNameTextField.value = "%@2";
+    levelSelector.value = "%@1";
+    songNameTextField.value = "%@2";
 
-do_djauto();
+    // do_djauto() reads its inputs from the form exposed as document.ref.
+    // Textage renders the autocomplete form without that name, so point
+    // document.ref at the form that actually holds these fields.
+    var autoCompleteForm = songNameTextField.form;
+    if (autoCompleteForm) {
+        var namedRef = document.getElementsByName("ref");
+        for (var i = namedRef.length - 1; i >= 0; i--) {
+            if (namedRef[i] !== autoCompleteForm) {
+                namedRef[i].setAttribute("name", "ref_search");
+            }
+        }
+        autoCompleteForm.setAttribute("name", "ref");
+    }
+
+    if (typeof do_djauto === "function") { do_djauto(); }
+})();
 """

--- a/Shared/JavaScript.swift
+++ b/Shared/JavaScript.swift
@@ -397,9 +397,6 @@ let textageNavigationJS = """
     levelSelector.value = "%@1";
     songNameTextField.value = "%@2";
 
-    // do_djauto() reads its inputs from the form exposed as document.ref.
-    // Textage renders the autocomplete form without that name, so point
-    // document.ref at the form that actually holds these fields.
     var autoCompleteForm = songNameTextField.form;
     if (autoCompleteForm) {
         var namedRef = document.getElementsByName("ref");


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to **33.2.5** (all targets).
- Fix the Textage viewer getting stuck on the loading spinner.

## Why it was stuck

The viewer injects values into Textage's "Direct Jump with AUTOcomplete" form and then calls the site's `do_djauto()` to navigate to the chart. `do_djauto()` reads its inputs from `document.ref`:

```js
str = document.ref.djauto.value;
...
tp  = document.ref.djauto_opt.value;
```

Textage now renders the autocomplete form as an **unnamed** `<form>`, and the only element named `ref` is the search form (`disp_refertable`), which has no `djauto`/`djauto_opt` fields. So `document.ref.djauto` is `undefined`, `do_djauto()` throws before navigating, and the WebView never leaves `index.html` — it stays at opacity 0 with the spinner showing until the fallback button appears.

## Fix

In the injected navigation script:
- Set the `djauto_opt` / `djauto` values via `getElementsByName` (with existence guards).
- Re-point `document.ref` at the form that actually holds those fields (renaming any other `ref` form) so `do_djauto()` can read them, then invoke it.

Also escape the song title before substituting it into the injected JS string so titles containing `"` or `\` can't break the script.

This is resilient to Textage's current state and to them restoring the form's `name` later.

## Test plan

- [ ] Open a song's Textage chart from the scores list — the chart loads instead of hanging on the spinner.
- [ ] Verify SP 1P/2P (NORMAL/HYPER/ANOTHER/LEGGENDARIA) and DP each jump to the correct chart.
- [ ] Try a song whose title contains a quote/special character and confirm it still loads.
- [ ] Confirm the "Open in Safari" fallback still appears if a song genuinely can't be found.

> Note: I could not build/run the iOS app in the cloud environment (no Xcode toolchain), so the above should be verified on device/simulator.

https://claude.ai/code/session_012fG15d7MbALDRUWMRuUtXU

---
_Generated by [Claude Code](https://claude.ai/code/session_012fG15d7MbALDRUWMRuUtXU)_