### PR TITLE
Fix Per Level card legend showing top segments out of order

### DIFF
--- a/DJDX/Views/Analytics/PerLevelAnalyticsCard.swift
+++ b/DJDX/Views/Analytics/PerLevelAnalyticsCard.swift
@@ -34,15 +34,13 @@ struct PerLevelAnalyticsCard<TrendChart: View>: View {
         segments.reduce(0) { $0 + $1.count }
     }
 
-    // The three largest segments, kept in the original segment order.
+    // The three largest segments, ordered by count descending.
     var topSegments: [PerLevelSegment] {
-        let topIDs = Set(
+        Array(
             segments.filter { $0.count > 0 }
                 .sorted { $0.count > $1.count }
                 .prefix(3)
-                .map(\.id)
         )
-        return segments.filter { topIDs.contains($0.id) }
     }
 
     var body: some View {


### PR DESCRIPTION
## Problem

The legend (stats row) on the **Per Level** analytics cards only shows 3 items, but they were not the top 3 by count and appeared out of order.

## Cause

In `PerLevelAnalyticsCard.swift`, the `topSegments` property correctly picked the three largest segments by count, but then returned them in the **original segment order** (e.g. AAA→F) rather than by count. As a result:

- The items shown were often not visually the top 3.
- They appeared out of order, since a smaller-count segment could be listed before a larger one.

## Fix

Return the top 3 segments sorted by count descending, so the legend matches the actual largest counts and reads in order.

```swift
var topSegments: [PerLevelSegment] {
    Array(
        segments.filter { $0.count > 0 }
            .sorted { $0.count > $1.count }
            .prefix(3)
    )
}
```

https://claude.ai/code/session_01PgLdbCsZztbf4kcJuiNuQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgLdbCsZztbf4kcJuiNuQK)_