### PR TITLE
Show 0 instead of no-data text on last play cards

### DIFF
--- a/DJDX/Views/Analytics/NewClearsCard.swift
+++ b/DJDX/Views/Analytics/NewClearsCard.swift
@@ -13,8 +13,9 @@ struct NewClearsCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4.0) {
             if newClears.isEmpty {
-                Text("Analytics.NoData")
-                    .font(.system(size: 14.0))
+                Text(verbatim: "0")
+                    .font(.system(size: 20.0, weight: .black))
+                    .fontWidth(.expanded)
                     .foregroundStyle(.secondary)
             } else {
                 Text("\(newClears.count)")

--- a/DJDX/Views/Analytics/NewDJLevelsCard.swift
+++ b/DJDX/Views/Analytics/NewDJLevelsCard.swift
@@ -13,8 +13,9 @@ struct NewDJLevelsCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4.0) {
             if newDJLevels.isEmpty {
-                Text("Analytics.NoData")
-                    .font(.system(size: 14.0))
+                Text(verbatim: "0")
+                    .font(.system(size: 20.0, weight: .black))
+                    .fontWidth(.expanded)
                     .foregroundStyle(.secondary)
             } else {
                 Text("\(newDJLevels.count)")

--- a/DJDX/Views/Analytics/NewHighScoresCard.swift
+++ b/DJDX/Views/Analytics/NewHighScoresCard.swift
@@ -13,8 +13,9 @@ struct NewHighScoresCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4.0) {
             if newHighScores.isEmpty {
-                Text("Analytics.NoData")
-                    .font(.system(size: 14.0))
+                Text(verbatim: "0")
+                    .font(.system(size: 20.0, weight: .black))
+                    .fontWidth(.expanded)
                     .foregroundStyle(.secondary)
             } else {
                 Text("\(newHighScores.count)")


### PR DESCRIPTION
## Summary

The last play (前回のプレー / `Analytics.Section.LastPlay`) summary cards previously displayed a localized "no data" string (`Analytics.NoData` → データなし / "No data") in a smaller font (size 14) when there were no new entries.

Now these cards show **`0`** instead, rendered in the **same font as a regular count** (size 20, weight `.black`, `.expanded` width) but in the **secondary color** so a zero reads as a muted-but-present count rather than a separate placeholder message.

## Changes

The last play cards are rendered by three shared card views, each updated identically (empty-state branch only):

- `DJDX/Views/Analytics/NewClearsCard.swift` — used by CLEAR, ASSIST/EASY/HARD/EX HARD CLEAR, FULLCOMBO CLEAR, and FAILED cards
- `DJDX/Views/Analytics/NewHighScoresCard.swift` — used by the New High Scores card
- `DJDX/Views/Analytics/NewDJLevelsCard.swift` — used by the AAA / AA / A cards

The non-empty branch (regular count) is unchanged. Detail/list views that use `Analytics.NoData` for an empty full-page state are intentionally left as-is.

https://claude.ai/code/session_018Xmz6gmBhD2UxainJXuWWL

---
_Generated by [Claude Code](https://claude.ai/code/session_018Xmz6gmBhD2UxainJXuWWL)_