### PR TITLE
Improve さかのぼる button behavior

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.3;
+				MARKETING_VERSION = 33.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -353,7 +353,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.3;
+				MARKETING_VERSION = 33.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -519,7 +519,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.3;
+				MARKETING_VERSION = 33.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -559,7 +559,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.3;
+				MARKETING_VERSION = 33.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
@@ -107,12 +107,14 @@ struct IIDXScoresView<Header: View>: View {
 
     @ViewBuilder var timeTravelButton: some View {
         let button = Button {
-            withAnimation {
-                isTimeTravelling.toggle()
-            }
-            if !isTimeTravelling {
-                playDataDate = .now
+            if isTimeTravelling {
+                // Already time travelling: tapping turns it off without showing the popover.
+                withAnimation {
+                    isTimeTravelling = false
+                }
             } else {
+                // Not time travelling: only show the popover. Selecting a non-today
+                // date is what turns the feature on (see onChange of playDataDate).
                 isShowingDatePopover = true
             }
         } label: {
@@ -313,6 +315,12 @@ struct IIDXScoresView<Header: View>: View {
             .onChange(of: playDataDate) { oldValue, newValue in
                 if !isSystemChangingCalendarDate,
                    !Calendar.current.isDate(oldValue, inSameDayAs: newValue) {
+                    if !isTimeTravelling, !Calendar.current.isDateInToday(newValue) {
+                        // Selecting a date other than today turns on time travelling.
+                        withAnimation {
+                            isTimeTravelling = true
+                        }
+                    }
                     reloadDisplay()
                 }
             }


### PR DESCRIPTION
## Summary

Refines the interaction model for the さかのぼる (time travel) button in the IIDX scores view so that opening the date popover and toggling the feature are decoupled.

### Previous behavior
- Tapping while **off** → toggled the feature **on** and showed the popover
- Tapping while **on** → toggled it **off** and reset the date

This meant simply opening the popover already activated the feature, even if the user dismissed it without choosing a date.

### New behavior
- Tapping while **off** → only shows the date popover (does **not** toggle the feature)
- Selecting a date that isn't today → toggles the feature **on**
- Tapping while **on** → toggles the feature **off** without showing the popover

## Changes
- `IIDXScoresView.swift`: rewrote the button action to branch on the current `isTimeTravelling` state instead of toggling unconditionally.
- `IIDXScoresView.swift`: in `onChange(of: playDataDate)`, turn on time travelling when a non-today date is selected.

https://claude.ai/code/session_015WiJGJjAbS3MWSF8W1ijTv

---
_Generated by [Claude Code](https://claude.ai/code/session_015WiJGJjAbS3MWSF8W1ijTv)_