### PR TITLE
Add 前回のプレー section and expandable 概要 cards to SDVX analytics

### DIFF
--- a/DJDX/Enums/ViewPath.swift
+++ b/DJDX/Enums/ViewPath.swift
@@ -31,6 +31,14 @@ enum AnalyticsPath: Hashable {
     case newADetail
 }
 
+enum SDVXAnalyticsPath: Hashable {
+    case clearBreakdownDetail
+    case gradeBreakdownDetail
+    case newHighScoresDetail
+    case newClearsDetail(clearType: String)
+    case newGradesDetail(grade: String)
+}
+
 enum ImportPath: Hashable {
     case importerWebIIDXSingle
     case importerWebIIDXDouble

--- a/DJDX/Games/SOUND VOLTEX/SDVXReader.swift
+++ b/DJDX/Games/SOUND VOLTEX/SDVXReader.swift
@@ -68,6 +68,11 @@ actor SDVXReader {
         }) ?? []
     }
 
+    // Import groups for a single version, newest-first (inherits allImportGroups' date-desc order).
+    func importGroups(for version: SDVXVersion) -> [SDVXImportGroupInfo] {
+        allImportGroups().filter { $0.version == version }
+    }
+
     // MARK: Song Records
 
     func songRecords(for importGroupID: String) -> [SDVXSongRecord] {

--- a/DJDX/Views/Analytics/SDVXAnalyticsCard.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsCard.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+enum SDVXAnalyticsCard: String, Codable, Hashable, CaseIterable {
+    case clearBreakdown
+    case gradeBreakdown
+    case newHighScores
+    case newClearComplete
+    case newClearExcessive
+    case newClearUltimateChain
+    case newClearPerfectUC
+    case newGradeS
+    case newGradeAAAPlus
+    case newGradeAAA
+
+    static var defaultOrder: [SDVXAnalyticsCard] { allCases }
+
+    var section: AnalyticsSection {
+        switch self {
+        case .clearBreakdown, .gradeBreakdown: return .overview
+        default: return .lastPlay
+        }
+    }
+
+    /// Clear-rank rawValue surfaced by a "new clear" card, if any.
+    var clearType: String? {
+        switch self {
+        case .newClearComplete: return SDVXClearType.complete.rawValue
+        case .newClearExcessive: return SDVXClearType.excessive.rawValue
+        case .newClearUltimateChain: return SDVXClearType.ultimateChain.rawValue
+        case .newClearPerfectUC: return SDVXClearType.perfectUltimateChain.rawValue
+        default: return nil
+        }
+    }
+
+    /// Grade rawValue surfaced by a "new grade" card, if any.
+    var grade: String? {
+        switch self {
+        case .newGradeS: return SDVXGrade.s.rawValue
+        case .newGradeAAAPlus: return SDVXGrade.aaaPlus.rawValue
+        case .newGradeAAA: return SDVXGrade.aaa.rawValue
+        default: return nil
+        }
+    }
+
+    var destination: SDVXAnalyticsPath? {
+        switch self {
+        case .clearBreakdown: return .clearBreakdownDetail
+        case .gradeBreakdown: return .gradeBreakdownDetail
+        case .newHighScores: return .newHighScoresDetail
+        default:
+            if let clearType { return .newClearsDetail(clearType: clearType) }
+            if let grade { return .newGradesDetail(grade: grade) }
+            return nil
+        }
+    }
+
+    var transitionID: String { "SDVX.\(rawValue)" }
+
+    var systemImage: String {
+        switch self {
+        case .clearBreakdown: return "chart.bar"
+        case .gradeBreakdown: return "chart.bar"
+        case .newHighScores: return "trophy"
+        case .newClearComplete, .newClearExcessive,
+             .newClearUltimateChain, .newClearPerfectUC: return "checkmark.circle"
+        case .newGradeS, .newGradeAAAPlus, .newGradeAAA: return "crown"
+        }
+    }
+
+    var iconColor: Color {
+        if let clearType { return SDVXClearType(rawValue: clearType)?.color ?? .gray }
+        if grade != nil { return .orange }
+        return .orange
+    }
+
+    var titleText: Text {
+        switch self {
+        case .newHighScores: return Text("Analytics.NewHighScores")
+        default:
+            if let clearType {
+                return Text(verbatim: SDVXClearType(rawValue: clearType)?.abbreviation ?? clearType)
+            }
+            if let grade { return Text(verbatim: grade) }
+            return Text(verbatim: "")
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func sdvxCardDraggable(
+        _ cardType: SDVXAnalyticsCard,
+        editing: Bool,
+        draggedCard: Binding<SDVXAnalyticsCard?>,
+        cardOrder: Binding<[SDVXAnalyticsCard]>,
+        onReorder: @escaping () -> Void
+    ) -> some View {
+        if editing {
+            self
+                .opacity(draggedCard.wrappedValue == cardType ? 0.4 : 1.0)
+                .onDrag {
+                    draggedCard.wrappedValue = cardType
+                    return NSItemProvider(object: cardType.rawValue as NSString)
+                }
+                .onDrop(of: [.text], delegate: SDVXCardReorderDropDelegate(
+                    target: cardType,
+                    cards: cardOrder,
+                    draggedCard: draggedCard,
+                    onReorder: onReorder
+                ))
+        } else {
+            self
+        }
+    }
+}
+
+struct SDVXCardReorderDropDelegate: DropDelegate {
+    let target: SDVXAnalyticsCard
+    @Binding var cards: [SDVXAnalyticsCard]
+    @Binding var draggedCard: SDVXAnalyticsCard?
+    let onReorder: () -> Void
+
+    func dropUpdated(info _: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info _: DropInfo) -> Bool {
+        draggedCard = nil
+        return true
+    }
+
+    func dropEntered(info _: DropInfo) {
+        guard let draggedCard, draggedCard != target else { return }
+        // Only reorder within the same section so cards can't jump between sections.
+        guard draggedCard.section == target.section else { return }
+        guard let fromIndex = cards.firstIndex(of: draggedCard),
+              let toIndex = cards.firstIndex(of: target) else { return }
+
+        withAnimation(.snappy(duration: 0.3)) {
+            cards.move(
+                fromOffsets: IndexSet(integer: fromIndex),
+                toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
+            )
+        }
+        onReorder()
+    }
+
+    func dropExited(info _: DropInfo) {
+        // No cleanup needed when a drag leaves this target
+    }
+}

--- a/DJDX/Views/Analytics/SDVXAnalyticsDestinationView.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsDestinationView.swift
@@ -1,0 +1,359 @@
+import Charts
+import OrderedCollections
+import SwiftUI
+
+struct SDVXAnalyticsDestinationView: View {
+
+    @Bindable var model: SDVXAnalyticsModel
+    let path: SDVXAnalyticsPath
+    var namespace: Namespace.ID
+
+    var body: some View {
+        Group {
+            switch path {
+            case .clearBreakdownDetail:
+                SDVXClearBreakdownDetailView(clearTypePerLevel: model.clearTypePerLevel)
+                    .navigationTitle("Analytics.SDVX.ClearBreakdown")
+                    .automaticNavigationTransition(id: "SDVX.clearBreakdown", in: namespace)
+            case .gradeBreakdownDetail:
+                SDVXGradeBreakdownDetailView(gradePerDifficulty: model.gradePerDifficulty)
+                    .navigationTitle("Analytics.SDVX.GradeBreakdown")
+                    .automaticNavigationTransition(id: "SDVX.gradeBreakdown", in: namespace)
+            case .newHighScoresDetail:
+                SDVXNewHighScoresDetailView(newHighScores: model.newHighScores)
+                    .navigationTitle("Analytics.NewHighScores")
+                    .automaticNavigationTransition(id: "SDVX.newHighScores", in: namespace)
+            case .newClearsDetail(let clearType):
+                SDVXNewClearsDetailView(newClears: model.newClears[clearType] ?? [])
+                    .navigationTitle(Text(verbatim: clearType))
+                    .automaticNavigationTransition(
+                        id: transitionID(forClearType: clearType), in: namespace
+                    )
+            case .newGradesDetail(let grade):
+                SDVXNewGradesDetailView(newGrades: model.newGrades[grade] ?? [])
+                    .navigationTitle(Text(verbatim: grade))
+                    .automaticNavigationTransition(id: transitionID(forGrade: grade), in: namespace)
+            }
+        }
+        .appBackgroundGradient()
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    func transitionID(forClearType clearType: String) -> String {
+        switch SDVXClearType(rawValue: clearType) {
+        case .complete: return "SDVX.newClearComplete"
+        case .excessive: return "SDVX.newClearExcessive"
+        case .ultimateChain: return "SDVX.newClearUltimateChain"
+        case .perfectUltimateChain: return "SDVX.newClearPerfectUC"
+        default: return "SDVX.newClears"
+        }
+    }
+
+    func transitionID(forGrade grade: String) -> String {
+        switch SDVXGrade(rawValue: grade) {
+        case .s: return "SDVX.newGradeS"
+        case .aaaPlus: return "SDVX.newGradeAAAPlus"
+        case .aaa: return "SDVX.newGradeAAA"
+        default: return "SDVX.newGrades"
+        }
+    }
+}
+
+// MARK: - Shared label
+
+// Difficulty + level chip, matching the trailing block in SDVXScoreRow.
+struct SDVXLevelLabel: View {
+    let difficulty: SDVXDifficulty
+    let level: String
+
+    var body: some View {
+        VStack(spacing: 1.0) {
+            Text(verbatim: difficulty.abbreviation)
+                .font(.system(size: 10.0).weight(.black))
+                .foregroundStyle(difficulty.color)
+            Text(verbatim: level)
+                .font(.system(size: 18.0).weight(.heavy))
+                .fontWidth(.condensed)
+                .monospacedDigit()
+        }
+        .padding([.top, .bottom], 6.0)
+        .frame(width: 78.0, alignment: .center)
+        .background(.thinMaterial)
+        .clipShape(.rect(cornerRadius: 6.0))
+    }
+}
+
+// MARK: - Last Play detail views
+
+struct SDVXNewClearsDetailView: View {
+    let newClears: [SDVXNewClearEntry]
+
+    var body: some View {
+        List {
+            if newClears.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newClears) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                Text(verbatim: SDVXClearType(rawValue: entry.previousClearType)?.abbreviation
+                                     ?? entry.previousClearType)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .strikethrough()
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                Text(verbatim: SDVXClearType(rawValue: entry.clearType)?.abbreviation
+                                     ?? entry.clearType)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(SDVXClearType(rawValue: entry.clearType)?.color ?? .primary)
+                            }
+                        }
+                        Spacer(minLength: 0.0)
+                        SDVXLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+struct SDVXNewGradesDetailView: View {
+    let newGrades: [SDVXNewGradeEntry]
+
+    var body: some View {
+        List {
+            if newGrades.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newGrades) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                Text(verbatim: entry.previousGrade)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fontWidth(.expanded)
+                                    .strikethrough()
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                Text(verbatim: entry.grade)
+                                    .font(.caption.weight(.semibold))
+                                    .fontWidth(.expanded)
+                                    .foregroundStyle(LinearGradient(colors: [.yellow, .orange],
+                                                                    startPoint: .top, endPoint: .bottom))
+                            }
+                            .fontWeight(.black)
+                        }
+                        Spacer(minLength: 0.0)
+                        SDVXLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+struct SDVXNewHighScoresDetailView: View {
+    let newHighScores: [SDVXNewHighScoreEntry]
+
+    var body: some View {
+        List {
+            if newHighScores.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newHighScores) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                Text("\(entry.previousScore)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .strikethrough()
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                Text("\(entry.newScore)")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.orange)
+                                Text("Analytics.NewHighScore.\(entry.newScore - entry.previousScore)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.orange.opacity(0.8))
+                            }
+                            if entry.newGrade != entry.previousGrade {
+                                HStack(spacing: 4.0) {
+                                    Text(verbatim: entry.previousGrade)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .fontWidth(.expanded)
+                                        .strikethrough()
+                                    Image(systemName: "arrow.right")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(verbatim: entry.newGrade)
+                                        .font(.caption.weight(.semibold))
+                                        .fontWidth(.expanded)
+                                        .foregroundStyle(LinearGradient(colors: [.yellow, .orange],
+                                                                        startPoint: .top, endPoint: .bottom))
+                                }
+                                .fontWeight(.black)
+                            }
+                        }
+                        Spacer(minLength: 0.0)
+                        SDVXLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+// MARK: - Overview expansion detail views
+
+struct SDVXClearBreakdownDetailView: View {
+    let clearTypePerLevel: [Int: OrderedDictionary<String, Int>]
+
+    var populatedLevels: [Int] {
+        clearTypePerLevel.filter { _, counts in
+            counts.values.contains(where: { $0 > 0 })
+        }.keys.sorted()
+    }
+
+    var body: some View {
+        List {
+            if populatedLevels.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                Section {
+                    ForEach(populatedLevels, id: \.self) { level in
+                        SDVXClearTypeLevelRow(counts: clearTypePerLevel[level] ?? [:], level: level)
+                            .listRowBackground(Color.clear)
+                    }
+                } header: {
+                    Text("Shared.Level")
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+struct SDVXClearTypeLevelRow: View {
+    let counts: OrderedDictionary<String, Int>
+    let level: Int
+
+    var total: Int { counts.values.reduce(0, +) }
+
+    var segments: [(type: String, count: Int)] {
+        SDVXClearType.sortedStringsWithoutNoPlay.compactMap { type in
+            let count = counts[type] ?? 0
+            return count > 0 ? (type, count) : nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6.0) {
+            HStack {
+                Text(verbatim: "LEVEL \(level)")
+                    .font(.subheadline.bold())
+                Spacer()
+                Text("Shared.SongCount.\(total)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            GeometryReader { geometry in
+                HStack(spacing: 0.0) {
+                    ForEach(segments, id: \.type) { segment in
+                        (SDVXClearType(rawValue: segment.type)?.color ?? .gray)
+                            .frame(width: geometry.size.width * CGFloat(segment.count) / CGFloat(max(total, 1)))
+                    }
+                }
+                .clipShape(.rect(cornerRadius: 4.0))
+            }
+            .frame(height: 16.0)
+        }
+        .padding(.vertical, 4.0)
+    }
+}
+
+struct SDVXGradeBreakdownDetailView: View {
+    let gradePerDifficulty: [SDVXDifficulty: OrderedDictionary<String, Int>]
+
+    var populatedDifficulties: [SDVXDifficulty] {
+        SDVXDifficulty.sorted.filter { difficulty in
+            (gradePerDifficulty[difficulty]?.values.contains(where: { $0 > 0 })) ?? false
+        }
+    }
+
+    var body: some View {
+        List {
+            if populatedDifficulties.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(populatedDifficulties, id: \.self) { difficulty in
+                    Section {
+                        Chart(gradeElements(for: difficulty), id: \.key) { element in
+                            BarMark(
+                                x: .value("Shared.SDVX.Grade", element.key),
+                                y: .value("Shared.ClearCount", element.value)
+                            )
+                            .foregroundStyle(LinearGradient(colors: [.yellow, .orange],
+                                                            startPoint: .bottom, endPoint: .top))
+                        }
+                        .frame(height: 140.0)
+                        .listRowBackground(Color.clear)
+                    } header: {
+                        Text(verbatim: difficulty.abbreviation)
+                            .foregroundStyle(difficulty.color)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    func gradeElements(for difficulty: SDVXDifficulty) -> [(key: String, value: Int)] {
+        let counts = gradePerDifficulty[difficulty] ?? [:]
+        return SDVXGrade.sortedStrings.compactMap { grade in
+            let count = counts[grade] ?? 0
+            return count > 0 ? (grade, count) : nil
+        }
+    }
+}

--- a/DJDX/Views/Analytics/SDVXAnalyticsModel.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsModel.swift
@@ -16,6 +16,25 @@ final class SDVXAnalyticsModel {
     var totalPlays: Int = 0
     var volforce: Double = 0.0
 
+    // "前回のプレー" (Last Play): improvements between the latest two import groups.
+    var newHighScores: [SDVXNewHighScoreEntry] = []
+    var newClears: [String: [SDVXNewClearEntry]] = [:]   // key = SDVXClearType.rawValue
+    var newGrades: [String: [SDVXNewGradeEntry]] = [:]   // key = SDVXGrade.rawValue
+
+    // Clear ranks surfaced as "new clear" cards (mirrors IIDX's per-type cards, minus PLAYED).
+    nonisolated static let trackedClearTypes: [String] = [
+        SDVXClearType.complete.rawValue,
+        SDVXClearType.excessive.rawValue,
+        SDVXClearType.ultimateChain.rawValue,
+        SDVXClearType.perfectUltimateChain.rawValue
+    ]
+    // Top grades surfaced as "new grade" cards (parallels IIDX's AAA/AA/A).
+    nonisolated static let trackedGrades: [String] = [
+        SDVXGrade.s.rawValue,
+        SDVXGrade.aaaPlus.rawValue,
+        SDVXGrade.aaa.rawValue
+    ]
+
     var dataState: DataState = .initializing
 
     let fetcher = SDVXReader()
@@ -75,6 +94,8 @@ final class SDVXAnalyticsModel {
         let topForces = records.map { chartForce($0) }.sorted(by: >).prefix(50)
         let computedVolforce = (topForces.reduce(0.0, +) * 100).rounded() / 100
 
+        let lastPlay = await computeLastPlay(version: version)
+
         withAnimation(.smooth.speed(2.0)) {
             self.clearTypePerDifficulty = clearByDiff
             self.gradePerDifficulty = gradeByDiff
@@ -82,7 +103,92 @@ final class SDVXAnalyticsModel {
             self.totalCharts = records.count
             self.totalPlays = plays
             self.volforce = computedVolforce
+            self.newClears = lastPlay.clears
+            self.newHighScores = lastPlay.highScores
+            self.newGrades = lastPlay.grades
             self.dataState = .presenting
         }
+    }
+
+    // Compares the latest two import groups for the version and computes what improved.
+    private func computeLastPlay(version: SDVXVersion) async -> (
+        clears: [String: [SDVXNewClearEntry]],
+        highScores: [SDVXNewHighScoreEntry],
+        grades: [String: [SDVXNewGradeEntry]]
+    ) {
+        let groups = await fetcher.importGroups(for: version)
+        guard groups.count >= 2 else {
+            return ([:], [], [:])
+        }
+        // importGroups is newest-first, so [0] is the latest and [1] the previous.
+        let latestRecords = await fetcher.songRecords(for: groups[0].id)
+        let previousRecords = await fetcher.songRecords(for: groups[1].id)
+        return Self.computeNewEntries(latestRecords: latestRecords, previousRecords: previousRecords)
+    }
+
+    nonisolated static func computeNewEntries(
+        latestRecords: [SDVXSongRecord],
+        previousRecords: [SDVXSongRecord]
+    ) -> (
+        clears: [String: [SDVXNewClearEntry]],
+        highScores: [SDVXNewHighScoreEntry],
+        grades: [String: [SDVXNewGradeEntry]]
+    ) {
+        func key(_ record: SDVXSongRecord) -> String {
+            "\(record.titleCompact())|\(record.difficulty)"
+        }
+
+        var previousByKey: [String: SDVXSongRecord] = [:]
+        previousByKey.reserveCapacity(previousRecords.count)
+        for record in previousRecords {
+            previousByKey[key(record)] = record
+        }
+
+        var clears: [String: [SDVXNewClearEntry]] =
+            Dictionary(uniqueKeysWithValues: trackedClearTypes.map { ($0, []) })
+        var grades: [String: [SDVXNewGradeEntry]] =
+            Dictionary(uniqueKeysWithValues: trackedGrades.map { ($0, []) })
+        var highScores: [SDVXNewHighScoreEntry] = []
+
+        for record in latestRecords {
+            let previous = previousByKey[key(record)]
+            let previousClearType = previous?.clearType ?? SDVXClearType.noPlay.rawValue
+            let previousGrade = previous?.grade ?? SDVXGrade.none.rawValue
+            let previousScore = previous?.highScore ?? 0
+
+            if trackedClearTypes.contains(record.clearType), record.clearType != previousClearType {
+                clears[record.clearType]?.append(SDVXNewClearEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    clearType: record.clearType,
+                    previousClearType: previousClearType
+                ))
+            }
+
+            if trackedGrades.contains(record.grade), record.grade != previousGrade {
+                grades[record.grade]?.append(SDVXNewGradeEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    grade: record.grade,
+                    previousGrade: previousGrade
+                ))
+            }
+
+            if record.highScore > previousScore {
+                highScores.append(SDVXNewHighScoreEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    newScore: record.highScore,
+                    previousScore: previousScore,
+                    newGrade: record.grade,
+                    previousGrade: previousGrade
+                ))
+            }
+        }
+
+        return (clears, highScores, grades)
     }
 }

--- a/DJDX/Views/Analytics/SDVXAnalyticsView.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsView.swift
@@ -118,7 +118,7 @@ struct SDVXAnalyticsView: View {
                         HStack(spacing: 12.0) {
                             ForEach(shownCards, id: \.self) { cardType in
                                 lastPlayCardView(for: cardType)
-                                    .frame(width: cardType.grade != nil ? 96.0 : 130.0)
+                                    .frame(width: cardType == .newHighScores ? 130.0 : 96.0)
                                     .editableCard(isVisible: visibleCards.contains(cardType),
                                                   isEditing: isEditing,
                                                   seed: cardOrder.firstIndex(of: cardType) ?? 0) {

--- a/DJDX/Views/Analytics/SDVXAnalyticsView.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsView.swift
@@ -3,13 +3,18 @@ import OrderedCollections
 import SwiftUI
 import UniformTypeIdentifiers
 
+// swiftlint:disable type_body_length
 struct SDVXAnalyticsView: View {
+
+    @EnvironmentObject var navigationManager: NavigationManager
 
     @Bindable var model: SDVXAnalyticsModel
 
     @AppStorage(wrappedValue: SDVXVersion.nabla, "Global.SDVX.Version") var sdvxVersion: SDVXVersion
 
     @Binding var isEditing: Bool
+
+    var analyticsNamespace: Namespace.ID
 
     @AppStorage(wrappedValue: Data(), "Analytics.SDVX.CardOrder") var cardOrderData: Data
     @State var cardOrder: [SDVXAnalyticsCard] = SDVXAnalyticsCard.defaultOrder
@@ -23,6 +28,9 @@ struct SDVXAnalyticsView: View {
     @AppStorage(wrappedValue: false, "Analytics.SDVX.OverviewCollapsed") var isOverviewCollapsedStored: Bool
     @State var isOverviewCollapsed: Bool = false
 
+    @AppStorage(wrappedValue: false, "Analytics.SDVX.LastPlayCollapsed") var isLastPlayCollapsedStored: Bool
+    @State var isLastPlayCollapsed: Bool = false
+
     let cardColumns = [
         GridItem(.flexible(), spacing: 12.0),
         GridItem(.flexible(), spacing: 12.0)
@@ -30,22 +38,87 @@ struct SDVXAnalyticsView: View {
 
     var body: some View {
         VStack(spacing: 20.0) {
-            let shownCards = isEditing ? cardOrder : cardOrder.filter { visibleCards.contains($0) }
-            if !shownCards.isEmpty {
-                let isExpanded = isEditing || !isOverviewCollapsed
-                VStack(spacing: 12.0) {
-                    AnalyticsSectionHeader(
-                        title: AnalyticsSection.overview.titleKey,
-                        isCollapsible: !isEditing,
-                        isExpanded: isExpanded
-                    ) {
-                        withAnimation(.smooth.speed(2.0)) { isOverviewCollapsed.toggle() }
-                        isOverviewCollapsedStored = isOverviewCollapsed
+            overviewSection
+            lastPlaySection
+        }
+        .padding(.top, 20.0)
+        .onAppear {
+            loadCardOrder()
+            loadVisibleCards()
+            isOverviewCollapsed = isOverviewCollapsedStored
+            isLastPlayCollapsed = isLastPlayCollapsedStored
+        }
+        .task {
+            if model.dataState == .initializing {
+                await model.reload(version: sdvxVersion)
+            }
+        }
+        .onChange(of: sdvxVersion) { _, _ in
+            Task { await model.reload(version: sdvxVersion) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dataImported)) { _ in
+            Task { await model.reload(version: sdvxVersion) }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    var overviewSection: some View {
+        let overviewCards = cardOrder.filter { $0.section == .overview }
+        let shownCards = isEditing ? overviewCards : overviewCards.filter { visibleCards.contains($0) }
+        if !shownCards.isEmpty {
+            let isExpanded = isEditing || !isOverviewCollapsed
+            VStack(spacing: 12.0) {
+                AnalyticsSectionHeader(
+                    title: AnalyticsSection.overview.titleKey,
+                    isCollapsible: !isEditing,
+                    isExpanded: isExpanded
+                ) {
+                    withAnimation(.smooth.speed(2.0)) { isOverviewCollapsed.toggle() }
+                    isOverviewCollapsedStored = isOverviewCollapsed
+                }
+                if isExpanded {
+                    LazyVGrid(columns: cardColumns, spacing: 12.0) {
+                        ForEach(shownCards, id: \.self) { cardType in
+                            overviewCardView(for: cardType)
+                                .editableCard(isVisible: visibleCards.contains(cardType),
+                                              isEditing: isEditing,
+                                              seed: cardOrder.firstIndex(of: cardType) ?? 0) {
+                                    toggleCard(cardType)
+                                }
+                                .sdvxCardDraggable(cardType, editing: isEditing,
+                                                   draggedCard: $draggedCard, cardOrder: $cardOrder,
+                                                   onReorder: saveCardOrder)
+                        }
                     }
-                    if isExpanded {
-                        LazyVGrid(columns: cardColumns, spacing: 12.0) {
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    var lastPlaySection: some View {
+        let lastPlayCards = cardOrder.filter { $0.section == .lastPlay }
+        let shownCards = isEditing ? lastPlayCards : lastPlayCards.filter { visibleCards.contains($0) }
+        if !shownCards.isEmpty {
+            let isExpanded = isEditing || !isLastPlayCollapsed
+            VStack(spacing: 12.0) {
+                AnalyticsSectionHeader(
+                    title: AnalyticsSection.lastPlay.titleKey,
+                    isCollapsible: !isEditing,
+                    isExpanded: isExpanded
+                ) {
+                    withAnimation(.smooth.speed(2.0)) { isLastPlayCollapsed.toggle() }
+                    isLastPlayCollapsedStored = isLastPlayCollapsed
+                }
+                if isExpanded {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12.0) {
                             ForEach(shownCards, id: \.self) { cardType in
-                                cardView(for: cardType)
+                                lastPlayCardView(for: cardType)
+                                    .frame(width: cardType.grade != nil ? 96.0 : 130.0)
                                     .editableCard(isVisible: visibleCards.contains(cardType),
                                                   isEditing: isEditing,
                                                   seed: cardOrder.firstIndex(of: cardType) ?? 0) {
@@ -61,32 +134,83 @@ struct SDVXAnalyticsView: View {
                 }
             }
         }
-        .padding(.top, 20.0)
-        .onAppear {
-            loadCardOrder()
-            loadVisibleCards()
-            isOverviewCollapsed = isOverviewCollapsedStored
-        }
-        .task {
-            if model.dataState == .initializing {
-                await model.reload(version: sdvxVersion)
+    }
+
+    // MARK: - Cards
+
+    @ViewBuilder
+    func overviewCardView(for cardType: SDVXAnalyticsCard) -> some View {
+        Button {
+            if !isEditing, let destination = cardType.destination {
+                navigationManager.push(destination)
+            }
+        } label: {
+            switch cardType {
+            case .clearBreakdown: clearBreakdownCard
+            case .gradeBreakdown: gradeBreakdownCard
+            default: EmptyView()
             }
         }
-        .onChange(of: sdvxVersion) { _, _ in
-            Task { await model.reload(version: sdvxVersion) }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .dataImported)) { _ in
-            Task { await model.reload(version: sdvxVersion) }
-        }
+        .buttonStyle(AnalyticsCardButtonStyle())
+        .automaticMatchedTransitionSource(id: cardType.transitionID, in: analyticsNamespace)
     }
 
     @ViewBuilder
-    func cardView(for cardType: SDVXAnalyticsCard) -> some View {
-        switch cardType {
-        case .clearBreakdown: clearBreakdownCard
-        case .gradeBreakdown: gradeBreakdownCard
+    func lastPlayCardView(for cardType: SDVXAnalyticsCard) -> some View {
+        Button {
+            if !isEditing, let destination = cardType.destination {
+                navigationManager.push(destination)
+            }
+        } label: {
+            lastPlayCountCard(for: cardType)
+        }
+        .buttonStyle(AnalyticsCardButtonStyle())
+        .automaticMatchedTransitionSource(id: cardType.transitionID, in: analyticsNamespace)
+    }
+
+    @ViewBuilder
+    func lastPlayCountCard(for cardType: SDVXAnalyticsCard) -> some View {
+        let count = lastPlayCount(for: cardType)
+        VStack(alignment: .leading, spacing: 2.0) {
+            Text("\(count)")
+                .font(.system(size: 20.0, weight: .black))
+                .fontWidth(.expanded)
+                .foregroundStyle(count > 0 ? .primary : .secondary)
+                .frame(height: 36.0, alignment: .topLeading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 5.0) {
+                Image(systemName: cardType.systemImage)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(cardType.iconColor)
+                    .frame(width: 12.0, height: 12.0)
+                cardType.titleText
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(12.0)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardBackground(cornerRadius: cardCornerRadius)
+    }
+
+    var cardCornerRadius: CGFloat {
+        if #available(iOS 26.0, *) {
+            return 20.0
+        } else {
+            return 12.0
         }
     }
+
+    func lastPlayCount(for cardType: SDVXAnalyticsCard) -> Int {
+        if cardType == .newHighScores { return model.newHighScores.count }
+        if let clearType = cardType.clearType { return model.newClears[clearType]?.count ?? 0 }
+        if let grade = cardType.grade { return model.newGrades[grade]?.count ?? 0 }
+        return 0
+    }
+
+    // MARK: - Card storage
 
     func loadCardOrder() {
         if let decoded = try? JSONDecoder().decode([SDVXAnalyticsCard].self, from: cardOrderData),
@@ -124,6 +248,8 @@ struct SDVXAnalyticsView: View {
             saveVisibleCards()
         }
     }
+
+    // MARK: - Overview card content
 
     // Aggregate clear-type counts across all difficulty categories
     var totalClearCounts: OrderedDictionary<String, Int> {
@@ -193,72 +319,4 @@ struct SDVXAnalyticsView: View {
         SDVXClearType(rawValue: rawValue)?.abbreviation ?? rawValue
     }
 }
-
-enum SDVXAnalyticsCard: String, Codable, Hashable, CaseIterable {
-    case clearBreakdown
-    case gradeBreakdown
-
-    static var defaultOrder: [SDVXAnalyticsCard] { allCases }
-}
-
-extension View {
-    @ViewBuilder
-    func sdvxCardDraggable(
-        _ cardType: SDVXAnalyticsCard,
-        editing: Bool,
-        draggedCard: Binding<SDVXAnalyticsCard?>,
-        cardOrder: Binding<[SDVXAnalyticsCard]>,
-        onReorder: @escaping () -> Void
-    ) -> some View {
-        if editing {
-            self
-                .opacity(draggedCard.wrappedValue == cardType ? 0.4 : 1.0)
-                .onDrag {
-                    draggedCard.wrappedValue = cardType
-                    return NSItemProvider(object: cardType.rawValue as NSString)
-                }
-                .onDrop(of: [.text], delegate: SDVXCardReorderDropDelegate(
-                    target: cardType,
-                    cards: cardOrder,
-                    draggedCard: draggedCard,
-                    onReorder: onReorder
-                ))
-        } else {
-            self
-        }
-    }
-}
-
-struct SDVXCardReorderDropDelegate: DropDelegate {
-    let target: SDVXAnalyticsCard
-    @Binding var cards: [SDVXAnalyticsCard]
-    @Binding var draggedCard: SDVXAnalyticsCard?
-    let onReorder: () -> Void
-
-    func dropUpdated(info _: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-
-    func performDrop(info _: DropInfo) -> Bool {
-        draggedCard = nil
-        return true
-    }
-
-    func dropEntered(info _: DropInfo) {
-        guard let draggedCard, draggedCard != target else { return }
-        guard let fromIndex = cards.firstIndex(of: draggedCard),
-              let toIndex = cards.firstIndex(of: target) else { return }
-
-        withAnimation(.snappy(duration: 0.3)) {
-            cards.move(
-                fromOffsets: IndexSet(integer: fromIndex),
-                toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
-            )
-        }
-        onReorder()
-    }
-
-    func dropExited(info _: DropInfo) {
-        // No cleanup needed when a drag leaves this target
-    }
-}
+// swiftlint:enable type_body_length

--- a/DJDX/Views/Analytics/SDVXNewEntries.swift
+++ b/DJDX/Views/Analytics/SDVXNewEntries.swift
@@ -1,0 +1,40 @@
+//
+//  SDVXNewEntries.swift
+//  DJDX
+//
+//  "前回のプレー" (Last Play) delta entries for SDVX. Mirrors the IIDX
+//  NewClearEntry / NewHighScoreEntry / NewDJLevelEntry types, but SDVX-shaped:
+//  the SDVX CSV is one row per chart, so each entry carries a single chart's
+//  level (String) and difficulty (SDVXDifficulty). SDVX records have no artist.
+//
+
+import Foundation
+
+struct SDVXNewClearEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: SDVXDifficulty
+    let clearType: String
+    let previousClearType: String
+}
+
+struct SDVXNewHighScoreEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: SDVXDifficulty
+    let newScore: Int
+    let previousScore: Int
+    let newGrade: String
+    let previousGrade: String
+}
+
+struct SDVXNewGradeEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: SDVXDifficulty
+    let grade: String
+    let previousGrade: String
+}

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -31,6 +31,7 @@ struct UnifiedView: View {
     @State var sdvxAnalyticsModel = SDVXAnalyticsModel()
 
     @Namespace var analyticsNamespace
+    @Namespace var sdvxAnalyticsNamespace
     @Namespace var towerNamespace
     @Namespace var importNamespace
 
@@ -102,6 +103,13 @@ struct UnifiedView: View {
                         id: path == .recent ? "Tower.Recent" : "Tower.Totals",
                         in: towerNamespace
                     )
+            }
+            .navigationDestination(for: SDVXAnalyticsPath.self) { path in
+                SDVXAnalyticsDestinationView(
+                    model: sdvxAnalyticsModel,
+                    path: path,
+                    namespace: sdvxAnalyticsNamespace
+                )
             }
         }
         .sheet(isPresented: $isPresentingImport) {
@@ -189,7 +197,8 @@ struct UnifiedView: View {
                     .transition(.scale(scale: 0.9).combined(with: .opacity))
             }
             if showAnalytics {
-                SDVXAnalyticsView(model: sdvxAnalyticsModel, isEditing: $isEditingAnalytics)
+                SDVXAnalyticsView(model: sdvxAnalyticsModel, isEditing: $isEditingAnalytics,
+                                  analyticsNamespace: sdvxAnalyticsNamespace)
                     .transition(.scale(scale: 0.9).combined(with: .opacity))
             }
         }


### PR DESCRIPTION
## Summary

Brings SDVX (SOUND VOLTEX) analytics to parity with beatmania IIDX by adding the two capabilities IIDX already had:

1. **前回のプレー / Last Play section** — a horizontally-scrolling row of summary cards that compares the **latest import group** against the **previous import group** for the selected version and surfaces what improved:
   - **New high scores** (old → new score with delta, plus grade change)
   - **New clears** per clear rank: `COMPLETE`, `EXCESSIVE COMPLETE`, `ULTIMATE CHAIN`, `PERFECT ULTIMATE CHAIN`
   - **New grades** for the top grades: `S`, `AAA+`, `AAA`
   
   Each card shows a count and is tappable, opening a detail list of the affected charts.

2. **Expandable 概要 / Overview cards** — the clear-breakdown and grade-breakdown cards are now tappable and expand into detail views (per-level clear breakdown, per-difficulty grade breakdown), matching how IIDX's overview card pushes a detail graph.

## Implementation notes

- SDVX already stores every import as a dated import group, so no schema/migration changes were needed — the comparison reuses `SDVXReader` and a new `importGroups(for:version:)` helper.
- The SDVX CSV is one row per chart, so last-play deltas are keyed by `titleCompact()` + difficulty. Comparison logic mirrors `AnalyticsModel.computeNewEntries`.
- New SDVX-shaped delta entry types (`SDVXNewClearEntry` / `SDVXNewHighScoreEntry` / `SDVXNewGradeEntry`), a `SDVXAnalyticsPath` enum, and `SDVXAnalyticsDestinationView` provide the navigation and detail views.
- The view follows the existing card ordering / visibility / drag-to-reorder and collapsible-section UX. Reordering is constrained within a section.
- No new localization strings — existing shared keys (`Analytics.Section.LastPlay` = 前回のプレー, `Analytics.NewHighScores`, `Analytics.NoData`, `Shared.Level`, `Shared.SongCount.%lld`, etc.) are reused.

## Files
- **New:** `SDVXAnalyticsCard.swift`, `SDVXAnalyticsDestinationView.swift`, `SDVXNewEntries.swift`
- **Edited:** `SDVXAnalyticsModel.swift`, `SDVXAnalyticsView.swift`, `SDVXReader.swift`, `ViewPath.swift`, `UnifiedView.swift`

## Testing

Not built/verified in this environment (no Swift/Xcode toolchain available — Linux). Manual verification suggested:
1. Switch the game selector to SOUND VOLTEX.
2. Import `SampleDataSDVX.csv` twice (changing a few clear ranks / scores between imports) so two import groups exist.
3. Confirm the 前回のプレー section appears with non-zero counts; tap each card to verify the detail list.
4. Tap the 概要 clear/grade cards and verify they expand into the per-level / per-difficulty detail views.
5. Verify edit mode (reorder / hide) works for both sections, and that with fewer than two import groups the cards read `0` / detail lists show no-data.

https://claude.ai/code/session_01RUcDSpJvhzCb7MibacHwKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUcDSpJvhzCb7MibacHwKR)_