### PR TITLE
Improve SDVX analytics cards and add Polaris Chord analytics

### DIFF
--- a/DJDX/Enums/AnalyticsCardType.swift
+++ b/DJDX/Enums/AnalyticsCardType.swift
@@ -117,7 +117,7 @@ enum AnalyticsCardType: String, Codable, CaseIterable, Identifiable {
         case .clearTypeOverall: return .blue
         case .towerRecent: return .red
         case .towerTotals: return .red
-        case .newHighScores: return .orange
+        case .newHighScores: return .primary
         case .newFullComboClear: return .blue
         case .newClears: return .cyan
         case .newEasyClears: return .green

--- a/DJDX/Enums/ViewPath.swift
+++ b/DJDX/Enums/ViewPath.swift
@@ -39,6 +39,12 @@ enum SDVXAnalyticsPath: Hashable {
     case newGradesDetail(grade: String)
 }
 
+enum PolarisChordAnalyticsPath: Hashable {
+    case newHighScoresDetail
+    case newClearsDetail(clearType: String)
+    case newGradesDetail(grade: String)
+}
+
 enum ImportPath: Hashable {
     case importerWebIIDXSingle
     case importerWebIIDXDouble

--- a/DJDX/Games/Polaris Chord/PolarisChordReader.swift
+++ b/DJDX/Games/Polaris Chord/PolarisChordReader.swift
@@ -68,6 +68,11 @@ actor PolarisChordReader {
         }) ?? []
     }
 
+    // Import groups for a single version, newest-first (inherits allImportGroups' date-desc order).
+    func importGroups(for version: PolarisChordVersion) -> [PolarisChordImportGroupInfo] {
+        allImportGroups().filter { $0.version == version }
+    }
+
     // MARK: Song Records
 
     func songRecords(for importGroupID: String) -> [PolarisChordSongRecord] {

--- a/DJDX/Views/Analytics/PolarisChordAnalyticsCard.swift
+++ b/DJDX/Views/Analytics/PolarisChordAnalyticsCard.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+enum PolarisChordAnalyticsCard: String, Codable, Hashable, CaseIterable {
+    case newHighScores
+    case newGradeSSSPlus
+    case newGradeSSS
+    case newGradeSS
+    case newGradeS
+    case newClearSuccess
+    case newClearFullCombo
+    case newClearAllPerfect
+
+    static var defaultOrder: [PolarisChordAnalyticsCard] { allCases }
+
+    static var defaultVisible: Set<PolarisChordAnalyticsCard> { Set(allCases) }
+
+    // Polaris Chord analytics only surfaces the "前回のプレー" (Last Play) section.
+    var section: AnalyticsSection { .lastPlay }
+
+    /// Clear-type rawValue surfaced by a "new clear" card, if any.
+    var clearType: String? {
+        switch self {
+        case .newClearSuccess: return PolarisChordClearType.success.rawValue
+        case .newClearFullCombo: return PolarisChordClearType.fullCombo.rawValue
+        case .newClearAllPerfect: return PolarisChordClearType.allPerfect.rawValue
+        default: return nil
+        }
+    }
+
+    /// Grade rawValue surfaced by a "new grade" card, if any.
+    var grade: String? {
+        switch self {
+        case .newGradeSSSPlus: return PolarisChordGrade.sssPlus.rawValue
+        case .newGradeSSS: return PolarisChordGrade.sss.rawValue
+        case .newGradeSS: return PolarisChordGrade.ss.rawValue
+        case .newGradeS: return PolarisChordGrade.s.rawValue
+        default: return nil
+        }
+    }
+
+    var destination: PolarisChordAnalyticsPath? {
+        switch self {
+        case .newHighScores: return .newHighScoresDetail
+        default:
+            if let clearType { return .newClearsDetail(clearType: clearType) }
+            if let grade { return .newGradesDetail(grade: grade) }
+            return nil
+        }
+    }
+
+    var transitionID: String { "PolarisChord.\(rawValue)" }
+
+    var systemImage: String {
+        switch self {
+        case .newHighScores: return "trophy"
+        case .newClearSuccess: return "checkmark.circle"
+        case .newClearFullCombo: return "star.circle"
+        case .newClearAllPerfect: return "star.circle.fill"
+        case .newGradeSSSPlus, .newGradeSSS, .newGradeSS, .newGradeS: return "crown"
+        }
+    }
+
+    var iconColor: Color {
+        // NEW RECORD uses the primary color (white/black per appearance).
+        if self == .newHighScores { return .primary }
+        if let clearType { return PolarisChordClearType(rawValue: clearType)?.color ?? .gray }
+        return .orange
+    }
+
+    var titleText: Text {
+        switch self {
+        case .newHighScores: return Text("Analytics.NewHighScores")
+        default:
+            if let clearType {
+                return Text(verbatim: PolarisChordClearType(rawValue: clearType)?.abbreviation ?? clearType)
+            }
+            if let grade { return Text(verbatim: grade) }
+            return Text(verbatim: "")
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func polarisChordCardDraggable(
+        _ cardType: PolarisChordAnalyticsCard,
+        editing: Bool,
+        draggedCard: Binding<PolarisChordAnalyticsCard?>,
+        cardOrder: Binding<[PolarisChordAnalyticsCard]>,
+        onReorder: @escaping () -> Void
+    ) -> some View {
+        if editing {
+            self
+                .opacity(draggedCard.wrappedValue == cardType ? 0.4 : 1.0)
+                .onDrag {
+                    draggedCard.wrappedValue = cardType
+                    return NSItemProvider(object: cardType.rawValue as NSString)
+                }
+                .onDrop(of: [.text], delegate: PolarisChordCardReorderDropDelegate(
+                    target: cardType,
+                    cards: cardOrder,
+                    draggedCard: draggedCard,
+                    onReorder: onReorder
+                ))
+        } else {
+            self
+        }
+    }
+}
+
+struct PolarisChordCardReorderDropDelegate: DropDelegate {
+    let target: PolarisChordAnalyticsCard
+    @Binding var cards: [PolarisChordAnalyticsCard]
+    @Binding var draggedCard: PolarisChordAnalyticsCard?
+    let onReorder: () -> Void
+
+    func dropUpdated(info _: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info _: DropInfo) -> Bool {
+        draggedCard = nil
+        return true
+    }
+
+    func dropEntered(info _: DropInfo) {
+        guard let draggedCard, draggedCard != target else { return }
+        guard let fromIndex = cards.firstIndex(of: draggedCard),
+              let toIndex = cards.firstIndex(of: target) else { return }
+
+        withAnimation(.snappy(duration: 0.3)) {
+            cards.move(
+                fromOffsets: IndexSet(integer: fromIndex),
+                toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
+            )
+        }
+        onReorder()
+    }
+
+    func dropExited(info _: DropInfo) {
+        // No cleanup needed when a drag leaves this target
+    }
+}

--- a/DJDX/Views/Analytics/PolarisChordAnalyticsDestinationView.swift
+++ b/DJDX/Views/Analytics/PolarisChordAnalyticsDestinationView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+struct PolarisChordAnalyticsDestinationView: View {
+
+    @Bindable var model: PolarisChordAnalyticsModel
+    let path: PolarisChordAnalyticsPath
+    var namespace: Namespace.ID
+
+    var body: some View {
+        Group {
+            switch path {
+            case .newHighScoresDetail:
+                PolarisChordNewHighScoresDetailView(newHighScores: model.newHighScores)
+                    .navigationTitle("Analytics.NewHighScores")
+                    .automaticNavigationTransition(id: "PolarisChord.newHighScores", in: namespace)
+            case .newClearsDetail(let clearType):
+                PolarisChordNewClearsDetailView(newClears: model.newClears[clearType] ?? [])
+                    .navigationTitle(Text(verbatim: clearType))
+                    .automaticNavigationTransition(
+                        id: transitionID(forClearType: clearType), in: namespace
+                    )
+            case .newGradesDetail(let grade):
+                PolarisChordNewGradesDetailView(newGrades: model.newGrades[grade] ?? [])
+                    .navigationTitle(Text(verbatim: grade))
+                    .automaticNavigationTransition(id: transitionID(forGrade: grade), in: namespace)
+            }
+        }
+        .appBackgroundGradient()
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    func transitionID(forClearType clearType: String) -> String {
+        switch PolarisChordClearType(rawValue: clearType) {
+        case .success: return "PolarisChord.newClearSuccess"
+        case .fullCombo: return "PolarisChord.newClearFullCombo"
+        case .allPerfect: return "PolarisChord.newClearAllPerfect"
+        default: return "PolarisChord.newClears"
+        }
+    }
+
+    func transitionID(forGrade grade: String) -> String {
+        switch PolarisChordGrade(rawValue: grade) {
+        case .sssPlus: return "PolarisChord.newGradeSSSPlus"
+        case .sss: return "PolarisChord.newGradeSSS"
+        case .ss: return "PolarisChord.newGradeSS"
+        case .s: return "PolarisChord.newGradeS"
+        default: return "PolarisChord.newGrades"
+        }
+    }
+}
+
+// MARK: - Shared label
+
+// Difficulty + level chip, matching the SDVX last-play detail label.
+struct PolarisChordLevelLabel: View {
+    let difficulty: PolarisChordDifficulty
+    let level: String
+
+    var body: some View {
+        VStack(spacing: 1.0) {
+            Text(verbatim: difficulty.abbreviation)
+                .font(.system(size: 10.0).weight(.black))
+                .foregroundStyle(difficulty.color)
+            Text(verbatim: level)
+                .font(.system(size: 18.0).weight(.heavy))
+                .fontWidth(.condensed)
+                .monospacedDigit()
+        }
+        .padding([.top, .bottom], 6.0)
+        .frame(width: 78.0, alignment: .center)
+        .background(.thinMaterial)
+        .clipShape(.rect(cornerRadius: 6.0))
+    }
+}
+
+// Styled grade text using the grade's own shape style.
+private struct PolarisChordGradeText: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let grade: String
+    var strikethrough: Bool = false
+
+    var body: some View {
+        let gradeEnum = PolarisChordGrade(rawValue: grade) ?? .unknown
+        Group {
+            if strikethrough {
+                Text(verbatim: grade)
+                    .strikethrough()
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(verbatim: grade)
+                    .foregroundStyle(AnyShapeStyle(gradeEnum.style(colorScheme: colorScheme)))
+            }
+        }
+        .font(.caption.weight(.semibold))
+        .fontWidth(.expanded)
+    }
+}
+
+// MARK: - Last Play detail views
+
+struct PolarisChordNewClearsDetailView: View {
+    let newClears: [PolarisChordNewClearEntry]
+
+    var body: some View {
+        List {
+            if newClears.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newClears) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                Text(verbatim: PolarisChordClearType(rawValue: entry.previousClearType)?.abbreviation
+                                     ?? entry.previousClearType)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .strikethrough()
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                let clear = PolarisChordClearType(rawValue: entry.clearType)
+                                Text(verbatim: clear?.abbreviation ?? entry.clearType)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(clear?.color ?? .primary)
+                            }
+                        }
+                        Spacer(minLength: 0.0)
+                        PolarisChordLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+struct PolarisChordNewGradesDetailView: View {
+    let newGrades: [PolarisChordNewGradeEntry]
+
+    var body: some View {
+        List {
+            if newGrades.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newGrades) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                PolarisChordGradeText(grade: entry.previousGrade, strikethrough: true)
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                PolarisChordGradeText(grade: entry.grade)
+                            }
+                            .fontWeight(.black)
+                        }
+                        Spacer(minLength: 0.0)
+                        PolarisChordLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+struct PolarisChordNewHighScoresDetailView: View {
+    let newHighScores: [PolarisChordNewHighScoreEntry]
+
+    var body: some View {
+        List {
+            if newHighScores.isEmpty {
+                Text("Analytics.NoData")
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            } else {
+                ForEach(newHighScores) { entry in
+                    HStack(alignment: .center, spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text(entry.songTitle)
+                                .bold()
+                                .fontWidth(.condensed)
+                            HStack(spacing: 4.0) {
+                                Text("\(entry.previousScore)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .strikethrough()
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                Text("\(entry.newScore)")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.primary)
+                            }
+                            if entry.newGrade != entry.previousGrade {
+                                HStack(spacing: 4.0) {
+                                    PolarisChordGradeText(grade: entry.previousGrade, strikethrough: true)
+                                    Image(systemName: "arrow.right")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    PolarisChordGradeText(grade: entry.newGrade)
+                                }
+                                .fontWeight(.black)
+                            }
+                        }
+                        Spacer(minLength: 0.0)
+                        PolarisChordLevelLabel(difficulty: entry.difficulty, level: entry.level)
+                    }
+                    .padding(.vertical, 2.0)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}

--- a/DJDX/Views/Analytics/PolarisChordAnalyticsModel.swift
+++ b/DJDX/Views/Analytics/PolarisChordAnalyticsModel.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class PolarisChordAnalyticsModel {
+
+    // "前回のプレー" (Last Play): improvements between the latest two import groups.
+    var newHighScores: [PolarisChordNewHighScoreEntry] = []
+    var newClears: [String: [PolarisChordNewClearEntry]] = [:]   // key = PolarisChordClearType.rawValue
+    var newGrades: [String: [PolarisChordNewGradeEntry]] = [:]   // key = PolarisChordGrade.rawValue
+
+    // Clear types surfaced as "new clear" cards (worst-to-best, mirroring SDVX).
+    nonisolated static let trackedClearTypes: [String] = [
+        PolarisChordClearType.success.rawValue,
+        PolarisChordClearType.fullCombo.rawValue,
+        PolarisChordClearType.allPerfect.rawValue
+    ]
+    // Top grades surfaced as "new grade" cards (SSS+ down to S).
+    nonisolated static let trackedGrades: [String] = [
+        PolarisChordGrade.sssPlus.rawValue,
+        PolarisChordGrade.sss.rawValue,
+        PolarisChordGrade.ss.rawValue,
+        PolarisChordGrade.s.rawValue
+    ]
+
+    var dataState: DataState = .initializing
+
+    let fetcher = PolarisChordReader()
+
+    func reload(version: PolarisChordVersion) async {
+        dataState = .loading
+
+        let lastPlay = await computeLastPlay(version: version)
+
+        withAnimation(.smooth.speed(2.0)) {
+            self.newClears = lastPlay.clears
+            self.newHighScores = lastPlay.highScores
+            self.newGrades = lastPlay.grades
+            self.dataState = .presenting
+        }
+    }
+
+    // Compares the latest two import groups for the version and computes what improved.
+    private func computeLastPlay(version: PolarisChordVersion) async -> (
+        clears: [String: [PolarisChordNewClearEntry]],
+        highScores: [PolarisChordNewHighScoreEntry],
+        grades: [String: [PolarisChordNewGradeEntry]]
+    ) {
+        let groups = await fetcher.importGroups(for: version)
+        guard groups.count >= 2 else {
+            return ([:], [], [:])
+        }
+        // importGroups is newest-first, so [0] is the latest and [1] the previous.
+        let latestRecords = await fetcher.songRecords(for: groups[0].id)
+        let previousRecords = await fetcher.songRecords(for: groups[1].id)
+        return Self.computeNewEntries(latestRecords: latestRecords, previousRecords: previousRecords)
+    }
+
+    nonisolated static func computeNewEntries(
+        latestRecords: [PolarisChordSongRecord],
+        previousRecords: [PolarisChordSongRecord]
+    ) -> (
+        clears: [String: [PolarisChordNewClearEntry]],
+        highScores: [PolarisChordNewHighScoreEntry],
+        grades: [String: [PolarisChordNewGradeEntry]]
+    ) {
+        func key(_ record: PolarisChordSongRecord) -> String {
+            "\(record.titleCompact())|\(record.difficulty)"
+        }
+
+        var previousByKey: [String: PolarisChordSongRecord] = [:]
+        previousByKey.reserveCapacity(previousRecords.count)
+        for record in previousRecords {
+            previousByKey[key(record)] = record
+        }
+
+        var clears: [String: [PolarisChordNewClearEntry]] =
+            Dictionary(uniqueKeysWithValues: trackedClearTypes.map { ($0, []) })
+        var grades: [String: [PolarisChordNewGradeEntry]] =
+            Dictionary(uniqueKeysWithValues: trackedGrades.map { ($0, []) })
+        var highScores: [PolarisChordNewHighScoreEntry] = []
+
+        for record in latestRecords {
+            let previous = previousByKey[key(record)]
+            let previousClearType = previous?.clearType ?? PolarisChordClearType.noPlay.rawValue
+            let previousGrade = previous?.grade ?? PolarisChordGrade.none.rawValue
+            let previousScore = previous?.score ?? 0
+
+            if trackedClearTypes.contains(record.clearType), record.clearType != previousClearType {
+                clears[record.clearType]?.append(PolarisChordNewClearEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    clearType: record.clearType,
+                    previousClearType: previousClearType
+                ))
+            }
+
+            if trackedGrades.contains(record.grade), record.grade != previousGrade {
+                grades[record.grade]?.append(PolarisChordNewGradeEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    grade: record.grade,
+                    previousGrade: previousGrade
+                ))
+            }
+
+            if record.score > previousScore {
+                highScores.append(PolarisChordNewHighScoreEntry(
+                    songTitle: record.title,
+                    level: record.level,
+                    difficulty: record.difficultyEnum,
+                    newScore: record.score,
+                    previousScore: previousScore,
+                    newGrade: record.grade,
+                    previousGrade: previousGrade
+                ))
+            }
+        }
+
+        return (clears, highScores, grades)
+    }
+}

--- a/DJDX/Views/Analytics/PolarisChordAnalyticsView.swift
+++ b/DJDX/Views/Analytics/PolarisChordAnalyticsView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+struct PolarisChordAnalyticsView: View {
+
+    @EnvironmentObject var navigationManager: NavigationManager
+
+    @Bindable var model: PolarisChordAnalyticsModel
+
+    @AppStorage(wrappedValue: PolarisChordVersion.polarisChord, "Global.PolarisChord.Version")
+    var polarisChordVersion: PolarisChordVersion
+
+    @Binding var isEditing: Bool
+
+    var analyticsNamespace: Namespace.ID
+
+    @AppStorage(wrappedValue: Data(), "Analytics.PolarisChord.CardOrder") var cardOrderData: Data
+    @State var cardOrder: [PolarisChordAnalyticsCard] = PolarisChordAnalyticsCard.defaultOrder
+    @State var draggedCard: PolarisChordAnalyticsCard?
+
+    @AppStorage(wrappedValue: Data(), "Analytics.PolarisChord.VisibleCards") var visibleCardsData: Data
+    @State var visibleCards: Set<PolarisChordAnalyticsCard> = PolarisChordAnalyticsCard.defaultVisible
+
+    // Persisted store; `isLastPlayCollapsed` mirrors it so a global `withAnimation`
+    // can drive the collapse (animating @AppStorage directly does not work).
+    @AppStorage(wrappedValue: false, "Analytics.PolarisChord.LastPlayCollapsed") var isLastPlayCollapsedStored: Bool
+    @State var isLastPlayCollapsed: Bool = false
+
+    var body: some View {
+        VStack(spacing: 20.0) {
+            lastPlaySection
+        }
+        .padding(.top, 20.0)
+        .onAppear {
+            loadCardOrder()
+            loadVisibleCards()
+            isLastPlayCollapsed = isLastPlayCollapsedStored
+        }
+        .task {
+            if model.dataState == .initializing {
+                await model.reload(version: polarisChordVersion)
+            }
+        }
+        .onChange(of: polarisChordVersion) { _, _ in
+            Task { await model.reload(version: polarisChordVersion) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dataImported)) { _ in
+            Task { await model.reload(version: polarisChordVersion) }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    var lastPlaySection: some View {
+        let lastPlayCards = cardOrder.filter { $0.section == .lastPlay }
+        let shownCards = isEditing ? lastPlayCards : lastPlayCards.filter { visibleCards.contains($0) }
+        if !shownCards.isEmpty {
+            let isExpanded = isEditing || !isLastPlayCollapsed
+            VStack(spacing: 12.0) {
+                AnalyticsSectionHeader(
+                    title: AnalyticsSection.lastPlay.titleKey,
+                    isCollapsible: !isEditing,
+                    isExpanded: isExpanded
+                ) {
+                    withAnimation(.smooth.speed(2.0)) { isLastPlayCollapsed.toggle() }
+                    isLastPlayCollapsedStored = isLastPlayCollapsed
+                }
+                if isExpanded {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12.0) {
+                            ForEach(shownCards, id: \.self) { cardType in
+                                lastPlayCardView(for: cardType)
+                                    .frame(width: cardType == .newHighScores ? 130.0 : 96.0)
+                                    .editableCard(isVisible: visibleCards.contains(cardType),
+                                                  isEditing: isEditing,
+                                                  seed: cardOrder.firstIndex(of: cardType) ?? 0) {
+                                        toggleCard(cardType)
+                                    }
+                                    .polarisChordCardDraggable(cardType, editing: isEditing,
+                                                               draggedCard: $draggedCard, cardOrder: $cardOrder,
+                                                               onReorder: saveCardOrder)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Cards
+
+    @ViewBuilder
+    func lastPlayCardView(for cardType: PolarisChordAnalyticsCard) -> some View {
+        Button {
+            if !isEditing, let destination = cardType.destination {
+                navigationManager.push(destination)
+            }
+        } label: {
+            lastPlayCountCard(for: cardType)
+        }
+        .buttonStyle(AnalyticsCardButtonStyle())
+        .automaticMatchedTransitionSource(id: cardType.transitionID, in: analyticsNamespace)
+    }
+
+    @ViewBuilder
+    func lastPlayCountCard(for cardType: PolarisChordAnalyticsCard) -> some View {
+        let count = lastPlayCount(for: cardType)
+        VStack(alignment: .leading, spacing: 2.0) {
+            Text("\(count)")
+                .font(.system(size: 20.0, weight: .black))
+                .fontWidth(.expanded)
+                .foregroundStyle(count > 0 ? .primary : .secondary)
+                .frame(height: 36.0, alignment: .topLeading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 5.0) {
+                Image(systemName: cardType.systemImage)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(cardType.iconColor)
+                    .frame(width: 12.0, height: 12.0)
+                cardType.titleText
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(12.0)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardBackground(cornerRadius: cardCornerRadius)
+    }
+
+    var cardCornerRadius: CGFloat {
+        if #available(iOS 26.0, *) {
+            return 20.0
+        } else {
+            return 12.0
+        }
+    }
+
+    func lastPlayCount(for cardType: PolarisChordAnalyticsCard) -> Int {
+        if cardType == .newHighScores { return model.newHighScores.count }
+        if let clearType = cardType.clearType { return model.newClears[clearType]?.count ?? 0 }
+        if let grade = cardType.grade { return model.newGrades[grade]?.count ?? 0 }
+        return 0
+    }
+
+    // MARK: - Card storage
+
+    func loadCardOrder() {
+        if let decoded = try? JSONDecoder().decode([PolarisChordAnalyticsCard].self, from: cardOrderData),
+           !decoded.isEmpty {
+            var order = decoded
+            for cardType in PolarisChordAnalyticsCard.defaultOrder where !order.contains(cardType) {
+                order.append(cardType)
+            }
+            order.removeAll { !PolarisChordAnalyticsCard.defaultOrder.contains($0) }
+            cardOrder = order
+        }
+    }
+
+    func saveCardOrder() {
+        cardOrderData = (try? JSONEncoder().encode(cardOrder)) ?? Data()
+    }
+
+    func loadVisibleCards() {
+        if let decoded = try? JSONDecoder().decode(Set<PolarisChordAnalyticsCard>.self, from: visibleCardsData) {
+            visibleCards = decoded
+        }
+    }
+
+    func saveVisibleCards() {
+        visibleCardsData = (try? JSONEncoder().encode(visibleCards)) ?? Data()
+    }
+
+    func toggleCard(_ cardType: PolarisChordAnalyticsCard) {
+        withAnimation(.smooth.speed(2.0)) {
+            if visibleCards.contains(cardType) {
+                visibleCards.remove(cardType)
+            } else {
+                visibleCards.insert(cardType)
+            }
+            saveVisibleCards()
+        }
+    }
+}

--- a/DJDX/Views/Analytics/PolarisChordNewEntries.swift
+++ b/DJDX/Views/Analytics/PolarisChordNewEntries.swift
@@ -1,0 +1,40 @@
+//
+//  PolarisChordNewEntries.swift
+//  DJDX
+//
+//  "前回のプレー" (Last Play) delta entries for Polaris Chord. Mirrors the
+//  SDVX entry types: one row per chart, carrying a single chart's level
+//  (String) and difficulty (PolarisChordDifficulty). Polaris Chord records
+//  have no artist.
+//
+
+import Foundation
+
+struct PolarisChordNewClearEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: PolarisChordDifficulty
+    let clearType: String
+    let previousClearType: String
+}
+
+struct PolarisChordNewHighScoreEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: PolarisChordDifficulty
+    let newScore: Int
+    let previousScore: Int
+    let newGrade: String
+    let previousGrade: String
+}
+
+struct PolarisChordNewGradeEntry: Identifiable, Hashable {
+    let id = UUID()
+    let songTitle: String
+    let level: String
+    let difficulty: PolarisChordDifficulty
+    let grade: String
+    let previousGrade: String
+}

--- a/DJDX/Views/Analytics/SDVXAnalyticsCard.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsCard.swift
@@ -11,8 +11,24 @@ enum SDVXAnalyticsCard: String, Codable, Hashable, CaseIterable {
     case newGradeS
     case newGradeAAAPlus
     case newGradeAAA
+    case newGradeAAPlus
+    case newGradeAA
+    case newGradeAPlus
+    case newGradeA
 
     static var defaultOrder: [SDVXAnalyticsCard] { allCases }
+
+    /// Cards shown by default. The grade cards are offered down to A, but only
+    /// the top grades (down to AAA) are visible until the user opts the rest in.
+    static var defaultVisible: Set<SDVXAnalyticsCard> {
+        [
+            .clearBreakdown, .gradeBreakdown,
+            .newHighScores,
+            .newClearComplete, .newClearExcessive,
+            .newClearUltimateChain, .newClearPerfectUC,
+            .newGradeS, .newGradeAAAPlus, .newGradeAAA
+        ]
+    }
 
     var section: AnalyticsSection {
         switch self {
@@ -38,6 +54,10 @@ enum SDVXAnalyticsCard: String, Codable, Hashable, CaseIterable {
         case .newGradeS: return SDVXGrade.s.rawValue
         case .newGradeAAAPlus: return SDVXGrade.aaaPlus.rawValue
         case .newGradeAAA: return SDVXGrade.aaa.rawValue
+        case .newGradeAAPlus: return SDVXGrade.aaPlus.rawValue
+        case .newGradeAA: return SDVXGrade.aa.rawValue
+        case .newGradeAPlus: return SDVXGrade.aPlus.rawValue
+        case .newGradeA: return SDVXGrade.a.rawValue
         default: return nil
         }
     }
@@ -63,13 +83,15 @@ enum SDVXAnalyticsCard: String, Codable, Hashable, CaseIterable {
         case .newHighScores: return "trophy"
         case .newClearComplete, .newClearExcessive,
              .newClearUltimateChain, .newClearPerfectUC: return "checkmark.circle"
-        case .newGradeS, .newGradeAAAPlus, .newGradeAAA: return "crown"
+        case .newGradeS, .newGradeAAAPlus, .newGradeAAA,
+             .newGradeAAPlus, .newGradeAA, .newGradeAPlus, .newGradeA: return "crown"
         }
     }
 
     var iconColor: Color {
+        // NEW RECORD uses the primary color (white/black per appearance).
+        if self == .newHighScores { return .primary }
         if let clearType { return SDVXClearType(rawValue: clearType)?.color ?? .gray }
-        if grade != nil { return .orange }
         return .orange
     }
 

--- a/DJDX/Views/Analytics/SDVXAnalyticsDestinationView.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsDestinationView.swift
@@ -54,6 +54,10 @@ struct SDVXAnalyticsDestinationView: View {
         case .s: return "SDVX.newGradeS"
         case .aaaPlus: return "SDVX.newGradeAAAPlus"
         case .aaa: return "SDVX.newGradeAAA"
+        case .aaPlus: return "SDVX.newGradeAAPlus"
+        case .aa: return "SDVX.newGradeAA"
+        case .aPlus: return "SDVX.newGradeAPlus"
+        case .a: return "SDVX.newGradeA"
         default: return "SDVX.newGrades"
         }
     }

--- a/DJDX/Views/Analytics/SDVXAnalyticsModel.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsModel.swift
@@ -28,11 +28,16 @@ final class SDVXAnalyticsModel {
         SDVXClearType.ultimateChain.rawValue,
         SDVXClearType.perfectUltimateChain.rawValue
     ]
-    // Top grades surfaced as "new grade" cards (parallels IIDX's AAA/AA/A).
+    // Grades surfaced as "new grade" cards, offered down to A (the view defaults
+    // to showing only the top grades, down to AAA).
     nonisolated static let trackedGrades: [String] = [
         SDVXGrade.s.rawValue,
         SDVXGrade.aaaPlus.rawValue,
-        SDVXGrade.aaa.rawValue
+        SDVXGrade.aaa.rawValue,
+        SDVXGrade.aaPlus.rawValue,
+        SDVXGrade.aa.rawValue,
+        SDVXGrade.aPlus.rawValue,
+        SDVXGrade.a.rawValue
     ]
 
     var dataState: DataState = .initializing

--- a/DJDX/Views/Analytics/SDVXAnalyticsView.swift
+++ b/DJDX/Views/Analytics/SDVXAnalyticsView.swift
@@ -21,7 +21,7 @@ struct SDVXAnalyticsView: View {
     @State var draggedCard: SDVXAnalyticsCard?
 
     @AppStorage(wrappedValue: Data(), "Analytics.SDVX.VisibleCards") var visibleCardsData: Data
-    @State var visibleCards: Set<SDVXAnalyticsCard> = Set(SDVXAnalyticsCard.allCases)
+    @State var visibleCards: Set<SDVXAnalyticsCard> = SDVXAnalyticsCard.defaultVisible
 
     // Persisted store; `isOverviewCollapsed` mirrors it so a global `withAnimation`
     // can drive the collapse (animating @AppStorage directly does not work).
@@ -305,12 +305,20 @@ struct SDVXAnalyticsView: View {
             Chart(totalGradeCounts.elements.filter { $0.value > 0 }, id: \.key) { element in
                 BarMark(
                     x: .value("Shared.ClearCount", element.value),
-                    y: .value("Grade", element.key)
+                    y: .value("Grade", element.key),
+                    height: .fixed(22.0)
                 )
-                .foregroundStyle(LinearGradient(colors: [.yellow, .orange],
-                                                startPoint: .leading, endPoint: .trailing))
+                .foregroundStyle(.orange)
+                .annotation(position: .overlay, alignment: .leading) {
+                    Text(verbatim: element.key)
+                        .font(.caption2.weight(.heavy))
+                        .fontWidth(.expanded)
+                        .foregroundStyle(.white)
+                        .padding(.leading, 6.0)
+                }
             }
             .chartXAxis { AxisMarks { AxisGridLine() } }
+            .chartYAxis(.hidden)
         }
         .perLevelCaption("Analytics.SDVX.GradeBreakdown")
     }

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -29,9 +29,11 @@ struct UnifiedView: View {
 
     @State var analyticsModel = AnalyticsModel()
     @State var sdvxAnalyticsModel = SDVXAnalyticsModel()
+    @State var polarisChordAnalyticsModel = PolarisChordAnalyticsModel()
 
     @Namespace var analyticsNamespace
     @Namespace var sdvxAnalyticsNamespace
+    @Namespace var polarisChordAnalyticsNamespace
     @Namespace var towerNamespace
     @Namespace var importNamespace
 
@@ -109,6 +111,13 @@ struct UnifiedView: View {
                     model: sdvxAnalyticsModel,
                     path: path,
                     namespace: sdvxAnalyticsNamespace
+                )
+            }
+            .navigationDestination(for: PolarisChordAnalyticsPath.self) { path in
+                PolarisChordAnalyticsDestinationView(
+                    model: polarisChordAnalyticsModel,
+                    path: path,
+                    namespace: polarisChordAnalyticsNamespace
                 )
             }
         }
@@ -216,9 +225,16 @@ struct UnifiedView: View {
                     .padding(.top, 16.0)
                     .transition(.scale(scale: 0.9).combined(with: .opacity))
             }
+            if showAnalytics {
+                PolarisChordAnalyticsView(model: polarisChordAnalyticsModel,
+                                          isEditing: $isEditingAnalytics,
+                                          analyticsNamespace: polarisChordAnalyticsNamespace)
+                    .transition(.scale(scale: 0.9).combined(with: .opacity))
+            }
         }
         .padding(.bottom, 8.0)
         .animation(.snappy, value: showProfileHeader)
+        .animation(.smooth.speed(2.0), value: showAnalytics)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Refines the SOUND VOLTEX analytics cards and introduces a brand-new analytics section for Polaris Chord.

### SDVX — 前回のプレー (Last Play)
- Now **offers new-grade cards down to A** (adds AA+, AA, A+, A alongside the existing S / AAA+ / AAA).
- **Default visibility still stops at AAA**, so the extra lower grades are opt-in via the edit mode — existing layouts are unaffected.

### SDVX — グレード内訳 (Grade Breakdown) card
- Removed the yellow→orange **gradient** in favor of a solid fill.
- **Thicker bars**, and the grade label is now rendered **inside the bar fill** instead of on the axis outside it.

### NEW RECORD icon
- Icon color changed to **primary** (white in dark mode, black in light mode) for **both SDVX and IIDX**.

### Polaris Chord — new analytics
- Adds a **前回のプレー (Last Play)** section only (no overview), mirroring the SDVX structure:
  - **NEW RECORD** (score improvements)
  - Grade cards: **SSS+, SSS, SS, S**
  - Clear cards: **NEW CLEAR** (SUCCESS), **NEW FC** (FULL COMBO), and **ALL PERFECT**
- Includes the model (last-play diff between the two latest import groups), card enum + drag-reorder, the section view, detail views, the `PolarisChordAnalyticsPath` routing, and wiring into `UnifiedView`.

## Notes
- New files land in the existing file-system-synchronized `Views/Analytics` group, so no `project.pbxproj` changes are required.
- This is a Swift/SwiftUI iOS project; it could not be compiled in the Linux execution environment, so the changes have been reviewed for correctness by hand and against the existing SDVX implementation they mirror.

https://claude.ai/code/session_011xwTn7b53gqcNdVcr2MNcM

---
_Generated by [Claude Code](https://claude.ai/code/session_011xwTn7b53gqcNdVcr2MNcM)_