### PR TITLE
Merge per-level analytics expanded views into a combined scrolling view

### DIFF
--- a/DJDX/Views/Analytics/AnalyticsDestinationView.swift
+++ b/DJDX/Views/Analytics/AnalyticsDestinationView.swift
@@ -91,61 +91,29 @@ struct AnalyticsDestinationView: View {
                 .navigationTitle("Analytics.Trends.DJLevel")
                 .automaticNavigationTransition(id: "Trends.DJLevel", in: analyticsNamespace)
             case .clearTypeForLevel(let difficulty):
-                VStack {
-                    TogglableClearTypeDetailView(
-                        graphData: $model.clearTypePerDifficulty,
-                        difficulty: .constant(difficulty)
+                ClearTypePerLevelDetailView(model: model, difficulty: difficulty)
+                    .navigationTitle(perLevelTitle(difficulty, .clearRate))
+                    .automaticNavigationTransition(
+                        id: "ClearType.Level.\(difficulty)", in: analyticsNamespace
                     )
-                    .chartLegend(.hidden)
-                    ClearTypeLegend()
-                        .padding(.horizontal)
-                }
-                .navigationTitle(perLevelTitle(difficulty, .clearRate))
-                .automaticNavigationTransition(
-                    id: "ClearType.Level.\(difficulty)", in: analyticsNamespace
-                )
             case .clearTypeTrendsForLevel(let difficulty):
-                VStack {
-                    TrendsClearTypeGraph(
-                        graphData: $model.clearTypePerImportGroup,
-                        difficulty: .constant(difficulty)
+                ClearTypePerLevelDetailView(model: model, difficulty: difficulty)
+                    .navigationTitle(perLevelTitle(difficulty, .clearRate))
+                    .automaticNavigationTransition(
+                        id: "ClearTypeTrends.Level.\(difficulty)", in: analyticsNamespace
                     )
-                    .chartLegend(.hidden)
-                    ClearTypeLegend()
-                }
-                .padding()
-                .navigationTitle(perLevelTitle(difficulty, .clearRateTrend))
-                .automaticNavigationTransition(
-                    id: "ClearTypeTrends.Level.\(difficulty)", in: analyticsNamespace
-                )
             case .djLevelForLevel(let difficulty):
-                VStack {
-                    TogglableDJLevelDetailView(
-                        graphData: $model.djLevelPerDifficulty,
-                        difficulty: .constant(difficulty)
+                DJLevelPerLevelDetailView(model: model, difficulty: difficulty)
+                    .navigationTitle(perLevelTitle(difficulty, .djLevel))
+                    .automaticNavigationTransition(
+                        id: "DJLevel.Level.\(difficulty)", in: analyticsNamespace
                     )
-                    .chartLegend(.hidden)
-                    DJLevelLegend()
-                        .padding(.horizontal)
-                }
-                .navigationTitle(perLevelTitle(difficulty, .djLevel))
-                .automaticNavigationTransition(
-                    id: "DJLevel.Level.\(difficulty)", in: analyticsNamespace
-                )
             case .djLevelTrendsForLevel(let difficulty):
-                VStack {
-                    TrendsDJLevelGraph(
-                        graphData: $model.djLevelPerImportGroup,
-                        difficulty: .constant(difficulty)
+                DJLevelPerLevelDetailView(model: model, difficulty: difficulty)
+                    .navigationTitle(perLevelTitle(difficulty, .djLevel))
+                    .automaticNavigationTransition(
+                        id: "DJLevelTrends.Level.\(difficulty)", in: analyticsNamespace
                     )
-                    .chartLegend(.hidden)
-                    DJLevelLegend()
-                }
-                .padding()
-                .navigationTitle(perLevelTitle(difficulty, .djLevelTrend))
-                .automaticNavigationTransition(
-                    id: "DJLevelTrends.Level.\(difficulty)", in: analyticsNamespace
-                )
             default:
                 newEntryDestination
             }

--- a/DJDX/Views/Analytics/PerLevelDetailView.swift
+++ b/DJDX/Views/Analytics/PerLevelDetailView.swift
@@ -1,0 +1,87 @@
+//
+//  PerLevelDetailView.swift
+//  DJDX
+//
+//  Created on 2026/06/04.
+//
+
+import Charts
+import OrderedCollections
+import SwiftUI
+
+// A small titled wrapper for one chart within a per-level detail view.
+struct PerLevelDetailSection<Content: View>: View {
+    let titleKey: LocalizedStringKey
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8.0) {
+            Text(titleKey)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+}
+
+// Combined scrolling detail view for a single level's clear lamp makeup and
+// its trend over time. Reachable from both the makeup and trend cards.
+struct ClearTypePerLevelDetailView: View {
+    @Bindable var model: AnalyticsModel
+    let difficulty: Int
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20.0) {
+                PerLevelDetailSection(titleKey: "Analytics.PerLevel.Breakdown") {
+                    TogglableClearTypeDetailView(
+                        graphData: $model.clearTypePerDifficulty,
+                        difficulty: .constant(difficulty)
+                    )
+                    .frame(height: 240.0)
+                }
+                PerLevelDetailSection(titleKey: "Analytics.PerLevel.Trend") {
+                    TrendsClearTypeGraph(
+                        graphData: $model.clearTypePerImportGroup,
+                        difficulty: .constant(difficulty)
+                    )
+                    .chartLegend(.hidden)
+                    .frame(height: 240.0)
+                }
+                ClearTypeLegend()
+            }
+            .padding()
+        }
+    }
+}
+
+// Combined scrolling detail view for a single level's DJ LEVEL makeup and its
+// trend over time. Reachable from both the makeup and trend cards.
+struct DJLevelPerLevelDetailView: View {
+    @Bindable var model: AnalyticsModel
+    let difficulty: Int
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20.0) {
+                PerLevelDetailSection(titleKey: "Analytics.PerLevel.Breakdown") {
+                    TogglableDJLevelDetailView(
+                        graphData: $model.djLevelPerDifficulty,
+                        difficulty: .constant(difficulty)
+                    )
+                    .frame(height: 240.0)
+                }
+                PerLevelDetailSection(titleKey: "Analytics.PerLevel.Trend") {
+                    TrendsDJLevelGraph(
+                        graphData: $model.djLevelPerImportGroup,
+                        difficulty: .constant(difficulty)
+                    )
+                    .chartLegend(.hidden)
+                    .frame(height: 240.0)
+                }
+                DJLevelLegend()
+            }
+            .padding()
+        }
+    }
+}

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -694,6 +694,23 @@
         }
       }
     },
+    "Analytics.PerLevel.Breakdown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breakdown"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内訳"
+          }
+        }
+      }
+    },
     "Analytics.PerLevel.ClearRate" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -758,6 +775,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DJ LEVEL推移"
+          }
+        }
+      }
+    },
+    "Analytics.PerLevel.Trend" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trend"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推移"
           }
         }
       }


### PR DESCRIPTION
## Summary

The per-level clear lamp and DJ LEVEL analytics cards previously opened two distinct expanded views depending on the card style:

- **Bar-style cards** (foreground makeup bar over a faint trend) opened a pie/bar makeup chart.
- **Background-only cards** (full trend graph) opened a trend-over-time graph.

This PR unifies those destinations. Both card styles now open a single scrolling expanded view that shows the selected level's **makeup** (togglable pie/bar) and its **trend over time** at the same time.

## Changes

- Added `PerLevelDetailView.swift` with:
  - `ClearTypePerLevelDetailView` and `DJLevelPerLevelDetailView` — scrolling views composing the existing togglable makeup chart and trend graph, each with its legend.
  - `PerLevelDetailSection` — a small titled wrapper for each chart section.
- `AnalyticsDestinationView` now routes all four per-level paths (`clearTypeForLevel`, `clearTypeTrendsForLevel`, `djLevelForLevel`, `djLevelTrendsForLevel`) to the combined views, preserving each card's own matched-transition source id.
- Added `Analytics.PerLevel.Breakdown` and `Analytics.PerLevel.Trend` localized section headers (EN/JA).

## Notes

- Per the design decision, **both card styles are kept** in the grid as-is; only their expanded destination is unified. No change to per-level card ordering/visibility persistence.
- The reused `TogglableClearTypeDetailView` / `TogglableDJLevelDetailView` keep the pie/bar toggle in the navigation bar toolbar, and remain in use by the overview destinations.

https://claude.ai/code/session_01SXwJ6FGCVw9E2qJtin5ja6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXwJ6FGCVw9E2qJtin5ja6)_