### PR TITLE
Add matched navigation transition to SDVX score viewer

### DIFF
--- a/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreRow.swift
+++ b/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreRow.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct SDVXScoreRow: View {
 
+    var namespace: Namespace.ID
+
     var record: SDVXSongRecord
 
     var body: some View {
@@ -42,6 +44,7 @@ struct SDVXScoreRow: View {
                 .font(.caption)
             }
             .padding([.top, .bottom], 8.0)
+            .automaticMatchedTransitionSource(id: "\(record.title).\(record.difficulty)", in: namespace)
 
             Spacer(minLength: 0.0)
 

--- a/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoresView.swift
+++ b/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoresView.swift
@@ -159,7 +159,7 @@ struct SDVXScoresView<Header: View>: View {
                         Button {
                             navigationManager.push(SDVXScoresPath.scoreViewer(songRecord: record))
                         } label: {
-                            SDVXScoreRow(record: record)
+                            SDVXScoreRow(namespace: sdvxNamespace, record: record)
                                 .contentShape(.rect)
                         }
                         .buttonStyle(.plain)
@@ -224,6 +224,8 @@ struct SDVXScoresView<Header: View>: View {
             switch viewPath {
             case .scoreViewer(let songRecord):
                 SDVXScoreViewer(songRecord: songRecord)
+                    .automaticNavigationTransition(id: "\(songRecord.title).\(songRecord.difficulty)",
+                                                   in: sdvxNamespace)
             case .chartViewer(let chart):
                 SDVXInChartViewer(chart: chart)
             }


### PR DESCRIPTION
## Summary

The SDVX score viewer was missing the zoom/matched navigation transition that the beatmania IIDX score viewer already uses. Tapping a row pushed the detail view with a plain default transition instead of the matched zoom animation.

This wires up the existing transition infrastructure for SDVX, mirroring the IIDX implementation:

- **`SDVXScoreRow`** — adds a `namespace: Namespace.ID` parameter and applies `.automaticMatchedTransitionSource(id:in:)` to the song-info area, using `"<title>.<difficulty>"` as the source ID.
- **`SDVXScoresView`** — passes `sdvxNamespace` into each `SDVXScoreRow`, and applies `.automaticNavigationTransition(id:in:)` to `SDVXScoreViewer` in the `navigationDestination` using the same ID format.

The `@Namespace var sdvxNamespace` already existed in `SDVXScoresView` (used for the filter sheet transition) and is now also reused for the row → viewer transition. The ID format matches IIDX's `"<title>.<level>"` convention.

## Testing

This is an iOS/SwiftUI change; it can't be built in this environment. The change reuses the same `AutomaticMatchedTransitionSource` / `AutomaticNavigationTransition` modifiers (iOS 18+) already proven in the IIDX flow, so behavior should match.

https://claude.ai/code/session_015LU3Zo1nD7MYDdi6F42ibc

---
_Generated by [Claude Code](https://claude.ai/code/session_015LU3Zo1nD7MYDdi6F42ibc)_