### PR TITLE
Add automatic nightly iCloud backups; remove SwiftData and bump to 33.4

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.3.2;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -353,7 +353,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.3.2;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -519,7 +519,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.3.2;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -559,7 +559,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.3.2;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DJDX/Classes/ICloudBackupManager.swift
+++ b/DJDX/Classes/ICloudBackupManager.swift
@@ -74,8 +74,8 @@ enum ICloudBackupManager {
         guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
             throw BackupError.documentsUnavailable
         }
-        let backupFolderURL = try backupFolderURL(in: fileManager)
-        try fileManager.createDirectory(at: backupFolderURL, withIntermediateDirectories: true)
+        let backupFolder = try backupFolderURL(in: fileManager)
+        try fileManager.createDirectory(at: backupFolder, withIntermediateDirectories: true)
 
         let stagingURL = fileManager.temporaryDirectory
             .appendingPathComponent("DJDXBackup-\(UUID().uuidString)")
@@ -84,7 +84,7 @@ enum ICloudBackupManager {
         try ZipArchive.zip(directoryAt: documentsURL, to: stagingURL)
 
         let backupDate = Date.now
-        let archiveURL = backupFolderURL.appendingPathComponent("Data.zip")
+        let archiveURL = backupFolder.appendingPathComponent("Data.zip")
         if fileManager.fileExists(atPath: archiveURL.path) {
             try fileManager.removeItem(at: archiveURL)
         }
@@ -92,7 +92,7 @@ enum ICloudBackupManager {
 
         let timestamp = ISO8601DateFormatter().string(from: backupDate)
         try Data(timestamp.utf8).write(
-            to: backupFolderURL.appendingPathComponent("LastBackup"),
+            to: backupFolder.appendingPathComponent("LastBackup"),
             options: .atomic
         )
 
@@ -103,11 +103,11 @@ enum ICloudBackupManager {
     // MARK: Restore
 
     static func existingBackupDate() async -> Date? {
-        await Task.detached(priority: .utility) { () -> Date? in
-            guard let backupFolderURL = try? backupFolderURL(in: FileManager.default) else {
+        await Task.detached(priority: .utility) { () async -> Date? in
+            guard let backupFolder = try? backupFolderURL(in: FileManager.default) else {
                 return nil
             }
-            let timestampURL = backupFolderURL.appendingPathComponent("LastBackup")
+            let timestampURL = backupFolder.appendingPathComponent("LastBackup")
             guard await ensureDownloaded(timestampURL, timeout: 30.0),
                   let timestamp = try? String(contentsOf: timestampURL, encoding: .utf8) else {
                 return nil
@@ -121,8 +121,8 @@ enum ICloudBackupManager {
     static func restore(onProgress: @escaping @Sendable (Int) -> Void) async throws {
         try await Task.detached(priority: .userInitiated) {
             let fileManager = FileManager.default
-            let backupFolderURL = try backupFolderURL(in: fileManager)
-            let archiveURL = backupFolderURL.appendingPathComponent("Data.zip")
+            let backupFolder = try backupFolderURL(in: fileManager)
+            let archiveURL = backupFolder.appendingPathComponent("Data.zip")
             onProgress(10)
             guard await ensureDownloaded(archiveURL, timeout: 600.0) else {
                 throw BackupError.downloadTimedOut

--- a/DJDX/Classes/ICloudBackupManager.swift
+++ b/DJDX/Classes/ICloudBackupManager.swift
@@ -1,0 +1,196 @@
+import BackgroundTasks
+import Foundation
+
+enum ICloudBackupManager {
+
+    static let backgroundTaskIdentifier = "com.tsubuzaki.DJDX.iCloudBackup"
+    static let enabledKey = "ICloudBackup.Enabled"
+    static let lastBackupDateKey = "ICloudBackup.LastBackupDate"
+    static let restorePromptCompletedKey = "ICloudBackup.RestorePromptCompleted"
+
+    enum BackupError: Error {
+        case iCloudUnavailable
+        case documentsUnavailable
+        case downloadTimedOut
+    }
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledKey)
+    }
+
+    // MARK: Background Task
+
+    static func registerBackgroundTask() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: backgroundTaskIdentifier,
+            using: nil
+        ) { task in
+            scheduleNextBackup()
+            guard isEnabled else {
+                task.setTaskCompleted(success: true)
+                return
+            }
+            do {
+                try backUp()
+                task.setTaskCompleted(success: true)
+            } catch {
+                task.setTaskCompleted(success: false)
+            }
+        }
+    }
+
+    static func scheduleNextBackup() {
+        guard isEnabled else { return }
+        let request = BGProcessingTaskRequest(identifier: backgroundTaskIdentifier)
+        request.requiresNetworkConnectivity = true
+        request.earliestBeginDate = Calendar.current.nextDate(
+            after: .now,
+            matching: DateComponents(hour: 0, minute: 0),
+            matchingPolicy: .nextTime
+        )
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    static func cancelScheduledBackup() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: backgroundTaskIdentifier)
+    }
+
+    // MARK: Backup
+
+    @discardableResult
+    static func performBackup() async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            do {
+                try backUp()
+                return true
+            } catch {
+                return false
+            }
+        }.value
+    }
+
+    static func backUp() throws {
+        let fileManager = FileManager.default
+        guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw BackupError.documentsUnavailable
+        }
+        let backupFolderURL = try backupFolderURL(in: fileManager)
+        try fileManager.createDirectory(at: backupFolderURL, withIntermediateDirectories: true)
+
+        let stagingURL = fileManager.temporaryDirectory
+            .appendingPathComponent("DJDXBackup-\(UUID().uuidString)")
+            .appendingPathExtension("zip")
+        defer { try? fileManager.removeItem(at: stagingURL) }
+        try ZipArchive.zip(directoryAt: documentsURL, to: stagingURL)
+
+        let backupDate = Date.now
+        let archiveURL = backupFolderURL.appendingPathComponent("Data.zip")
+        if fileManager.fileExists(atPath: archiveURL.path) {
+            try fileManager.removeItem(at: archiveURL)
+        }
+        try fileManager.moveItem(at: stagingURL, to: archiveURL)
+
+        let timestamp = ISO8601DateFormatter().string(from: backupDate)
+        try Data(timestamp.utf8).write(
+            to: backupFolderURL.appendingPathComponent("LastBackup"),
+            options: .atomic
+        )
+
+        UserDefaults.standard.set(backupDate.timeIntervalSince1970, forKey: lastBackupDateKey)
+        UserDefaults.standard.set(true, forKey: restorePromptCompletedKey)
+    }
+
+    // MARK: Restore
+
+    static func existingBackupDate() async -> Date? {
+        await Task.detached(priority: .utility) { () -> Date? in
+            guard let backupFolderURL = try? backupFolderURL(in: FileManager.default) else {
+                return nil
+            }
+            let timestampURL = backupFolderURL.appendingPathComponent("LastBackup")
+            guard await ensureDownloaded(timestampURL, timeout: 30.0),
+                  let timestamp = try? String(contentsOf: timestampURL, encoding: .utf8) else {
+                return nil
+            }
+            return ISO8601DateFormatter().date(
+                from: timestamp.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }.value
+    }
+
+    static func restore(onProgress: @escaping @Sendable (Int) -> Void) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let fileManager = FileManager.default
+            let backupFolderURL = try backupFolderURL(in: fileManager)
+            let archiveURL = backupFolderURL.appendingPathComponent("Data.zip")
+            onProgress(10)
+            guard await ensureDownloaded(archiveURL, timeout: 600.0) else {
+                throw BackupError.downloadTimedOut
+            }
+            onProgress(70)
+            guard let documentsURL = fileManager.urls(
+                for: .documentDirectory, in: .userDomainMask
+            ).first else {
+                throw BackupError.documentsUnavailable
+            }
+
+            let extractionURL = fileManager.temporaryDirectory
+                .appendingPathComponent("DJDXRestore-\(UUID().uuidString)", isDirectory: true)
+            defer { try? fileManager.removeItem(at: extractionURL) }
+            try ZipArchive.unzip(fileAt: archiveURL, to: extractionURL)
+            onProgress(90)
+
+            var restoreRootURL = extractionURL
+            let extractedItems = try fileManager.contentsOfDirectory(
+                at: extractionURL, includingPropertiesForKeys: [.isDirectoryKey]
+            )
+            if extractedItems.count == 1,
+               extractedItems[0].lastPathComponent == documentsURL.lastPathComponent,
+               (try? extractedItems[0].resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                restoreRootURL = extractedItems[0]
+            }
+            for item in try fileManager.contentsOfDirectory(
+                at: restoreRootURL, includingPropertiesForKeys: nil
+            ) {
+                let destinationURL = documentsURL.appendingPathComponent(item.lastPathComponent)
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
+                }
+                try fileManager.moveItem(at: item, to: destinationURL)
+            }
+            onProgress(100)
+        }.value
+    }
+
+    // MARK: iCloud
+
+    private static func backupFolderURL(in fileManager: FileManager) throws -> URL {
+        guard let containerURL = fileManager.url(forUbiquityContainerIdentifier: nil) else {
+            throw BackupError.iCloudUnavailable
+        }
+        return containerURL
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Backup", isDirectory: true)
+    }
+
+    private static func ensureDownloaded(_ url: URL, timeout: TimeInterval) async -> Bool {
+        let fileManager = FileManager.default
+        let deadline = Date.now.addingTimeInterval(timeout)
+        while Date.now < deadline {
+            if isFullyDownloaded(url) { return true }
+            try? fileManager.startDownloadingUbiquitousItem(at: url)
+            try? await Task.sleep(for: .seconds(1))
+        }
+        return isFullyDownloaded(url)
+    }
+
+    private static func isFullyDownloaded(_ url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+        guard let status = try? url.resourceValues(
+            forKeys: [.ubiquitousItemDownloadingStatusKey]
+        ).ubiquitousItemDownloadingStatus else {
+            return true
+        }
+        return status == .current || status == .downloaded
+    }
+}

--- a/DJDX/Classes/ZipArchive.swift
+++ b/DJDX/Classes/ZipArchive.swift
@@ -1,0 +1,189 @@
+import Compression
+import Foundation
+
+enum ZipArchive {
+
+    enum ZipArchiveError: Error {
+        case invalidArchive
+        case unsupportedEntry
+        case decompressionFailed
+        case invalidEntryPath
+    }
+
+    static func zip(directoryAt sourceURL: URL, to destinationURL: URL) throws {
+        let fileManager = FileManager.default
+        var coordinatorError: NSError?
+        var operationError: Error?
+        NSFileCoordinator().coordinate(
+            readingItemAt: sourceURL,
+            options: .forUploading,
+            error: &coordinatorError
+        ) { zippedURL in
+            do {
+                try fileManager.createDirectory(
+                    at: destinationURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
+                }
+                try fileManager.copyItem(at: zippedURL, to: destinationURL)
+            } catch {
+                operationError = error
+            }
+        }
+        if let coordinatorError {
+            throw coordinatorError
+        }
+        if let operationError {
+            throw operationError
+        }
+    }
+
+    static func unzip(fileAt archiveURL: URL, to destinationURL: URL) throws {
+        let data = try Data(contentsOf: archiveURL)
+        let endRecord = try endOfCentralDirectory(in: data)
+        var offset = endRecord.centralDirectoryOffset
+        for _ in 0..<endRecord.entryCount {
+            offset = try extractEntry(at: offset, in: data, to: destinationURL)
+        }
+    }
+
+    private struct EndOfCentralDirectory {
+        let entryCount: Int
+        let centralDirectoryOffset: Int
+    }
+
+    private static func endOfCentralDirectory(in data: Data) throws -> EndOfCentralDirectory {
+        let recordSize = 22
+        guard data.count >= recordSize else { throw ZipArchiveError.invalidArchive }
+        let searchStart = max(0, data.count - recordSize - Int(UInt16.max))
+        var offset = data.count - recordSize
+        while offset >= searchStart {
+            if read(UInt32.self, in: data, at: offset) == 0x06054B50 {
+                let entryCount = Int(read(UInt16.self, in: data, at: offset + 10))
+                let centralDirectoryOffset = Int(read(UInt32.self, in: data, at: offset + 16))
+                guard entryCount != Int(UInt16.max), centralDirectoryOffset != Int(UInt32.max) else {
+                    throw ZipArchiveError.unsupportedEntry
+                }
+                return EndOfCentralDirectory(
+                    entryCount: entryCount,
+                    centralDirectoryOffset: centralDirectoryOffset
+                )
+            }
+            offset -= 1
+        }
+        throw ZipArchiveError.invalidArchive
+    }
+
+    // swiftlint:disable:next function_body_length
+    private static func extractEntry(at offset: Int, in data: Data, to destinationURL: URL) throws -> Int {
+        guard offset + 46 <= data.count,
+              read(UInt32.self, in: data, at: offset) == 0x02014B50 else {
+            throw ZipArchiveError.invalidArchive
+        }
+        let compressionMethod = read(UInt16.self, in: data, at: offset + 10)
+        let compressedSize = Int(read(UInt32.self, in: data, at: offset + 20))
+        let uncompressedSize = Int(read(UInt32.self, in: data, at: offset + 24))
+        let nameLength = Int(read(UInt16.self, in: data, at: offset + 28))
+        let extraLength = Int(read(UInt16.self, in: data, at: offset + 30))
+        let commentLength = Int(read(UInt16.self, in: data, at: offset + 32))
+        let localHeaderOffset = Int(read(UInt32.self, in: data, at: offset + 42))
+        let nextEntryOffset = offset + 46 + nameLength + extraLength + commentLength
+
+        guard compressedSize != Int(UInt32.max),
+              uncompressedSize != Int(UInt32.max),
+              localHeaderOffset != Int(UInt32.max) else {
+            throw ZipArchiveError.unsupportedEntry
+        }
+        guard offset + 46 + nameLength <= data.count,
+              let name = String(
+                data: data.subdata(in: (offset + 46)..<(offset + 46 + nameLength)),
+                encoding: .utf8
+              ) else {
+            throw ZipArchiveError.invalidArchive
+        }
+
+        let pathComponents = name.split(separator: "/").map(String.init).filter { $0 != "." }
+        guard !pathComponents.contains(".."), !name.hasPrefix("/") else {
+            throw ZipArchiveError.invalidEntryPath
+        }
+        guard !pathComponents.isEmpty else { return nextEntryOffset }
+        var entryURL = destinationURL
+        for pathComponent in pathComponents {
+            entryURL.appendPathComponent(pathComponent)
+        }
+
+        let fileManager = FileManager.default
+        if name.hasSuffix("/") {
+            try fileManager.createDirectory(at: entryURL, withIntermediateDirectories: true)
+            return nextEntryOffset
+        }
+
+        guard localHeaderOffset + 30 <= data.count,
+              read(UInt32.self, in: data, at: localHeaderOffset) == 0x04034B50 else {
+            throw ZipArchiveError.invalidArchive
+        }
+        let localNameLength = Int(read(UInt16.self, in: data, at: localHeaderOffset + 26))
+        let localExtraLength = Int(read(UInt16.self, in: data, at: localHeaderOffset + 28))
+        let dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength
+        guard dataStart + compressedSize <= data.count else {
+            throw ZipArchiveError.invalidArchive
+        }
+        let compressedData = data.subdata(in: dataStart..<(dataStart + compressedSize))
+
+        let fileData: Data
+        switch compressionMethod {
+        case 0:
+            fileData = compressedData
+        case 8:
+            fileData = try inflate(compressedData, uncompressedSize: uncompressedSize)
+        default:
+            throw ZipArchiveError.unsupportedEntry
+        }
+
+        try fileManager.createDirectory(
+            at: entryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if fileManager.fileExists(atPath: entryURL.path) {
+            try fileManager.removeItem(at: entryURL)
+        }
+        try fileData.write(to: entryURL)
+        return nextEntryOffset
+    }
+
+    private static func inflate(_ compressedData: Data, uncompressedSize: Int) throws -> Data {
+        guard uncompressedSize > 0 else { return Data() }
+        guard !compressedData.isEmpty else { throw ZipArchiveError.decompressionFailed }
+        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: uncompressedSize)
+        defer { destinationBuffer.deallocate() }
+        let decodedSize = compressedData.withUnsafeBytes { sourceBytes -> Int in
+            guard let sourcePointer = sourceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                return 0
+            }
+            return compression_decode_buffer(
+                destinationBuffer,
+                uncompressedSize,
+                sourcePointer,
+                compressedData.count,
+                nil,
+                COMPRESSION_ZLIB
+            )
+        }
+        guard decodedSize == uncompressedSize else {
+            throw ZipArchiveError.decompressionFailed
+        }
+        return Data(bytes: destinationBuffer, count: decodedSize)
+    }
+
+    private static func read<T: FixedWidthInteger>(_ type: T.Type, in data: Data, at offset: Int) -> T {
+        let size = MemoryLayout<T>.size
+        guard offset >= 0, offset + size <= data.count else { return 0 }
+        var value: T = 0
+        for index in 0..<size {
+            value |= T(data[offset + index]) << (8 * index)
+        }
+        return value
+    }
+}

--- a/DJDX/Extensions/Notification.swift
+++ b/DJDX/Extensions/Notification.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 extension Notification.Name {
-    static let dataMigrationCompleted = Notification.Name("DJDX.DataMigrationCompleted")
     static let dataImported = Notification.Name("DJDX.DataImported")
     static let analyticsLayoutReset = Notification.Name("DJDX.AnalyticsLayoutReset")
     static let profileRefreshRequested = Notification.Name("DJDX.ProfileRefreshRequested")

--- a/DJDX/Games/Polaris Chord/Data Types/PolarisChordSongRecord.swift
+++ b/DJDX/Games/Polaris Chord/Data Types/PolarisChordSongRecord.swift
@@ -1,9 +1,7 @@
 import Foundation
-import SwiftData
 
 // Polaris Chord has no CSV export; each record is built from a chart in the
 // json/pdata_getdata.html API response. Stored via SQLite, like SDVXSongRecord.
-@Model
 final class PolarisChordSongRecord: Equatable, Hashable, @unchecked Sendable {
     var title: String = ""
     var musicID: String = ""
@@ -15,9 +13,7 @@ final class PolarisChordSongRecord: Equatable, Hashable, @unchecked Sendable {
     var clearType: String = PolarisChordClearType.noPlay.rawValue
     var grade: String = PolarisChordGrade.none.rawValue
 
-    init() {
-        // Empty default initializer required by SwiftData
-    }
+    init() {}
 
     init(jsonRow: [String: Any]) {
         self.title = jsonRow["title"] as? String ?? ""
@@ -76,6 +72,15 @@ final class PolarisChordSongRecord: Equatable, Hashable, @unchecked Sendable {
         lhs.achievementRate == rhs.achievementRate &&
         lhs.clearType == rhs.clearType &&
         lhs.grade == rhs.grade
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(titleCompact())
+        hasher.combine(difficulty)
+        hasher.combine(level)
+        hasher.combine(achievementRate)
+        hasher.combine(clearType)
+        hasher.combine(grade)
     }
 
     func hash(into hasher: inout Hasher) {

--- a/DJDX/Games/Polaris Chord/Data Types/PolarisChordSongRecord.swift
+++ b/DJDX/Games/Polaris Chord/Data Types/PolarisChordSongRecord.swift
@@ -77,14 +77,5 @@ final class PolarisChordSongRecord: Equatable, Hashable, @unchecked Sendable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(titleCompact())
         hasher.combine(difficulty)
-        hasher.combine(level)
-        hasher.combine(achievementRate)
-        hasher.combine(clearType)
-        hasher.combine(grade)
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(titleCompact())
-        hasher.combine(difficulty)
     }
 }

--- a/DJDX/Games/SOUND VOLTEX/Data Types/SDVXSongRecord.swift
+++ b/DJDX/Games/SOUND VOLTEX/Data Types/SDVXSongRecord.swift
@@ -61,14 +61,5 @@ final class SDVXSongRecord: Equatable, Hashable, @unchecked Sendable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(titleCompact())
         hasher.combine(difficulty)
-        hasher.combine(level)
-        hasher.combine(highScore)
-        hasher.combine(clearType)
-        hasher.combine(grade)
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(titleCompact())
-        hasher.combine(difficulty)
     }
 }

--- a/DJDX/Games/SOUND VOLTEX/Data Types/SDVXSongRecord.swift
+++ b/DJDX/Games/SOUND VOLTEX/Data Types/SDVXSongRecord.swift
@@ -1,10 +1,8 @@
 import Foundation
-import SwiftData
 
 // The SDVX CSV is one row per chart (song + difficulty), unlike the IIDX CSV
 // which is one row per song. Each SDVXSongRecord therefore carries a single
 // chart's score.
-@Model
 final class SDVXSongRecord: Equatable, Hashable, @unchecked Sendable {
     var title: String = ""
     var difficulty: String = SDVXDifficulty.novice.rawValue
@@ -18,9 +16,7 @@ final class SDVXSongRecord: Equatable, Hashable, @unchecked Sendable {
     var ultimateChainCount: Int = 0
     var perfectCount: Int = 0
 
-    init() {
-        // Empty default initializer required by SwiftData
-    }
+    init() {}
 
     // Based on the SDVX e-amusement CSV format.
     init(csvRowData: [String: Any]) {
@@ -60,6 +56,15 @@ final class SDVXSongRecord: Equatable, Hashable, @unchecked Sendable {
         lhs.highScore == rhs.highScore &&
         lhs.clearType == rhs.clearType &&
         lhs.grade == rhs.grade
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(titleCompact())
+        hasher.combine(difficulty)
+        hasher.combine(level)
+        hasher.combine(highScore)
+        hasher.combine(clearType)
+        hasher.combine(grade)
     }
 
     func hash(into hasher: inout Hasher) {

--- a/DJDX/Games/beatmania IIDX/Data Types/IIDXSong.swift
+++ b/DJDX/Games/beatmania IIDX/Data Types/IIDXSong.swift
@@ -1,7 +1,5 @@
 import Foundation
-import SwiftData
 
-@Model
 final class IIDXSong: Equatable, @unchecked Sendable {
     var title: String = ""
     var spNoteCount: IIDXNoteCount?
@@ -10,9 +8,7 @@ final class IIDXSong: Equatable, @unchecked Sendable {
     var movie: String = ""
     var layer: String = ""
 
-    init() {
-        // Empty default initializer required by SwiftData
-    }
+    init() {}
 
     init(_ tableColumnData: [String]) {
         self.title = tableColumnData[0]
@@ -59,6 +55,10 @@ final class IIDXSong: Equatable, @unchecked Sendable {
 
     func titleCompact() -> String {
         return title.compact
+    }
+
+    static func == (lhs: IIDXSong, rhs: IIDXSong) -> Bool {
+        return lhs.title == rhs.title
     }
 
     static func == (lhs: IIDXSong, rhs: IIDXSongRecord) -> Bool {

--- a/DJDX/Games/beatmania IIDX/Data Types/IIDXSongRecord.swift
+++ b/DJDX/Games/beatmania IIDX/Data Types/IIDXSongRecord.swift
@@ -1,9 +1,7 @@
 import Foundation
-import SwiftData
 
 let songLevelCSVHeaders: [String] = ["BEGINNER", "NORMAL", "HYPER", "ANOTHER", "LEGGENDARIA"]
 
-@Model
 final class IIDXSongRecord: Equatable, Hashable, @unchecked Sendable {
     var version: String = ""
     var title: String = ""
@@ -18,11 +16,7 @@ final class IIDXSongRecord: Equatable, Hashable, @unchecked Sendable {
     var playType: IIDXPlayType = IIDXPlayType.single
     var lastPlayDate: Date = Date.distantPast
 
-    var importGroup: ImportGroup?
-
-    init() {
-        // Empty default initializer required by SwiftData
-    }
+    init() {}
 
     // Based on EPOLIS CSV format
     init(csvRowData: [String: Any], playType: IIDXPlayType? = nil) {
@@ -120,6 +114,12 @@ final class IIDXSongRecord: Equatable, Hashable, @unchecked Sendable {
         let lhsTitle = lhs.titleCompact()
         let rhsTitle = rhs.titleCompact()
         return lhsTitle == rhsTitle
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(titleCompact())
+        hasher.combine(artist)
+        hasher.combine(playType)
     }
 }
 

--- a/DJDX/Games/beatmania IIDX/Data Types/IIDXTowerEntry.swift
+++ b/DJDX/Games/beatmania IIDX/Data Types/IIDXTowerEntry.swift
@@ -1,7 +1,5 @@
 import Foundation
-import SwiftData
 
-@Model
 final class IIDXTowerEntry: @unchecked Sendable {
     var playDate: Date = Date.distantPast
     var keyCount: Int = 0

--- a/DJDX/Games/beatmania IIDX/IIDXImporter.swift
+++ b/DJDX/Games/beatmania IIDX/IIDXImporter.swift
@@ -323,39 +323,6 @@ actor IIDXImporter {
         }
     }
 
-    // MARK: Migration
-
-    func migrateImportGroup(
-        _ importGroup: ImportGroup,
-        songRecords: [IIDXSongRecord]
-    ) {
-        guard let database = try? IIDXPlayDataDatabase.shared.getWriteConnection() else { return }
-        let col = IIDXPlayDataDatabase.self
-        try? database.transaction {
-            try database.run(col.importGroupTable.insert(
-                col.igID <- importGroup.id,
-                col.igImportDate <- importGroup.importDate.timeIntervalSince1970,
-                col.igIIDXVersion <- importGroup.iidxVersion?.rawValue
-            ))
-            for record in songRecords {
-                Self.insertSongRecord(database: database, record: record, importGroupID: importGroup.id)
-            }
-        }
-    }
-
-    func migrateSongs(_ songs: [IIDXSong]) {
-        insertSongs(songs)
-    }
-
-    func migrateTowerEntries(_ entries: [IIDXTowerEntry]) {
-        guard let database = try? IIDXPlayDataDatabase.shared.getWriteConnection() else { return }
-        try? database.transaction {
-            for entry in entries {
-                Self.insertTowerEntry(database: database, entry: entry)
-            }
-        }
-    }
-
     // MARK: Delete Helpers
 
     func deleteImportGroup(id: String) {

--- a/DJDX/Games/beatmania IIDX/IIDXReader.swift
+++ b/DJDX/Games/beatmania IIDX/IIDXReader.swift
@@ -580,7 +580,6 @@ actor IIDXReader {
     static func importGroup(from row: Row) -> ImportGroup {
         let group = ImportGroup(
             importDate: Date(timeIntervalSince1970: row[IIDXPlayDataDatabase.igImportDate]),
-            iidxData: [],
             iidxVersion: row[IIDXPlayDataDatabase.igIIDXVersion].flatMap { IIDXVersion(rawValue: $0) } ?? .epolis
         )
         group.id = row[IIDXPlayDataDatabase.igID]

--- a/DJDX/Games/beatmania IIDX/ImportGroup.swift
+++ b/DJDX/Games/beatmania IIDX/ImportGroup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class ImportGroup: @unchecked Sendable {
+final class ImportGroup: Identifiable, @unchecked Sendable {
     var id: String = UUID().uuidString
     var importDate: Date = Date.distantPast
     var iidxVersion: IIDXVersion?

--- a/DJDX/Games/beatmania IIDX/ImportGroup.swift
+++ b/DJDX/Games/beatmania IIDX/ImportGroup.swift
@@ -1,16 +1,12 @@
 import Foundation
-import SwiftData
 
-@Model
 final class ImportGroup: @unchecked Sendable {
     var id: String = UUID().uuidString
     var importDate: Date = Date.distantPast
-    @Relationship(deleteRule: .cascade, inverse: \IIDXSongRecord.importGroup) var iidxData: [IIDXSongRecord]?
     var iidxVersion: IIDXVersion?
 
-    init(importDate: Date, iidxData: [IIDXSongRecord], iidxVersion: IIDXVersion) {
+    init(importDate: Date, iidxVersion: IIDXVersion) {
         self.importDate = importDate
-        self.iidxData = iidxData
         self.iidxVersion = iidxVersion
     }
 }

--- a/DJDX/Info.plist
+++ b/DJDX/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.tsubuzaki.DJDX.iCloudBackup</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -51,6 +55,7 @@
 	<array>
 		<string>remote-notification</string>
 		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/DJDX/Views/Analytics/AnalyticsView.swift
+++ b/DJDX/Views/Analytics/AnalyticsView.swift
@@ -331,9 +331,6 @@ struct AnalyticsView: View {
                     debugPrint("Reloaded on change of version")
                 }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .dataMigrationCompleted)) { _ in
-                Task { await reload() }
-            }
             .onReceive(NotificationCenter.default.publisher(for: .dataImported)) { _ in
                 Task { await reload() }
             }

--- a/DJDX/Views/App.swift
+++ b/DJDX/Views/App.swift
@@ -17,6 +17,8 @@ struct DJDXApp: App {
 
     init() {
         _ = IIDXPlayDataDatabase.shared
+        ICloudBackupManager.registerBackgroundTask()
+        ICloudBackupManager.scheduleNextBackup()
         Task {
             let playTypeRaw = UserDefaults.standard.string(forKey: "ScoresView.PlayTypeFilter") ?? "single"
             let playType = IIDXPlayType(rawValue: playTypeRaw) ?? .single

--- a/DJDX/Views/App.swift
+++ b/DJDX/Views/App.swift
@@ -1,4 +1,3 @@
-import SwiftData
 import SwiftUI
 import WidgetKit
 
@@ -11,7 +10,6 @@ struct DJDXApp: App {
         WindowGroup {
             UnifiedView()
         }
-        .modelContainer(sharedModelContainer)
         .environmentObject(navigationManager)
     }
 
@@ -28,19 +26,3 @@ struct DJDXApp: App {
         }
     }
 }
-
-let sharedModelContainer: ModelContainer = {
-    let schema = Schema([
-        ImportGroup.self,
-        IIDXSongRecord.self,
-        IIDXSong.self,
-        IIDXTowerEntry.self
-    ])
-    let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-    do {
-        return try ModelContainer(for: schema, configurations: [modelConfiguration])
-    } catch {
-        fatalError("Could not create ModelContainer: \(error)")
-    }
-}()

--- a/DJDX/Views/More/MoreICloudBackup.swift
+++ b/DJDX/Views/More/MoreICloudBackup.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct MoreICloudBackup: View {
+
+    @Environment(\.dismiss) var dismiss
+
+    @AppStorage(wrappedValue: false, ICloudBackupManager.enabledKey) var isBackupEnabled: Bool
+    @AppStorage(wrappedValue: 0.0, ICloudBackupManager.lastBackupDateKey) var lastBackupDate: Double
+    @AppStorage(wrappedValue: false, ICloudBackupManager.restorePromptCompletedKey)
+    var hasCompletedRestorePrompt: Bool
+
+    @State var isBackingUp: Bool = false
+    @State var isBackupFailed: Bool = false
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("ICloudBackup.Enable", systemImage: "icloud", isOn: $isBackupEnabled)
+            } footer: {
+                Text("ICloudBackup.Description")
+            }
+            if isBackupEnabled {
+                Section {
+                    LabeledContent("ICloudBackup.LastBackup") {
+                        if lastBackupDate > 0.0 {
+                            Text(Date(timeIntervalSince1970: lastBackupDate), format: .dateTime)
+                        } else {
+                            Text("ICloudBackup.LastBackup.Never")
+                        }
+                    }
+                    Button {
+                        backUpNow()
+                    } label: {
+                        HStack {
+                            Text("ICloudBackup.BackUpNow")
+                            if isBackingUp {
+                                Spacer()
+                                ProgressView()
+                            }
+                        }
+                    }
+                    .disabled(isBackingUp)
+                }
+            }
+        }
+        .navigationTitle("ICloudBackup.Title")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if #available(iOS 26.0, *) {
+                    Button(role: .close) {
+                        dismiss()
+                    }
+                } else {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .tint(.primary)
+                            .font(.title2)
+                            .symbolRenderingMode(.hierarchical)
+                    }
+                }
+            }
+        }
+        .animation(.smooth.speed(2.0), value: isBackupEnabled)
+        .onChange(of: isBackupEnabled) { _, newValue in
+            if newValue {
+                hasCompletedRestorePrompt = true
+                ICloudBackupManager.scheduleNextBackup()
+            } else {
+                ICloudBackupManager.cancelScheduledBackup()
+            }
+        }
+        .alert("Alert.ICloudBackup.Failed.Title", isPresented: $isBackupFailed) {
+            Button("Shared.OK", role: .cancel) {
+                isBackupFailed = false
+            }
+        } message: {
+            Text("Alert.ICloudBackup.Failed.Subtitle")
+        }
+    }
+
+    func backUpNow() {
+        isBackingUp = true
+        Task {
+            let isSuccessful = await ICloudBackupManager.performBackup()
+            isBackingUp = false
+            if !isSuccessful {
+                isBackupFailed = true
+            }
+        }
+    }
+}

--- a/DJDX/Views/More/MoreMenu.swift
+++ b/DJDX/Views/More/MoreMenu.swift
@@ -14,6 +14,7 @@ struct MoreMenu: View {
     let polarisChordImporter = PolarisChordImporter()
 
     @State var isPresentingExternalDataSources: Bool = false
+    @State var isPresentingICloudBackup: Bool = false
     @State var isConfirmingWebDataDelete: Bool = false
     @State var isConfirmingResetLayout: Bool = false
     @State var isPromptingScoreDeleteCode: Bool = false
@@ -66,6 +67,9 @@ struct MoreMenu: View {
                 }
             }
             Section("More.ManageData.Header") {
+                Button("More.ManageData.ICloudBackup", systemImage: "icloud") {
+                    isPresentingICloudBackup = true
+                }
                 Button("More.ManageData.ResetLayout", systemImage: "arrow.counterclockwise", role: .destructive) {
                     isConfirmingResetLayout = true
                 }
@@ -92,6 +96,11 @@ struct MoreMenu: View {
         .sheet(isPresented: $isPresentingExternalDataSources) {
             NavigationStack {
                 MoreExternalDataSources()
+            }
+        }
+        .sheet(isPresented: $isPresentingICloudBackup) {
+            NavigationStack {
+                MoreICloudBackup()
             }
         }
         .alert("Alert.DeleteData.Web.Title", isPresented: $isConfirmingWebDataDelete) {

--- a/DJDX/Views/Shared/ProgressCard.swift
+++ b/DJDX/Views/Shared/ProgressCard.swift
@@ -12,25 +12,36 @@ struct ProgressCard: View {
         ZStack(alignment: .center) {
             Color.black.opacity(colorScheme == .dark ? 0.5 : 0.2)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            VStack(alignment: .center, spacing: 0.0) {
-                VStack(alignment: .center, spacing: 10.0) {
-                    Text(LocalizedStringKey(title))
-                        .bold()
-                        .multilineTextAlignment(.center)
-                    ProgressView(value: min(Float(percentage), 100.0), total: 100.0)
-                        .progressViewStyle(.linear)
-                    Text(NSLocalizedString(message, comment: "")
-                        .replacingOccurrences(of: "%1", with: String(percentage)))
-                    .font(.subheadline)
-                    .multilineTextAlignment(.center)
-                }
-                .padding()
+            if #available(iOS 26.0, *) {
+                contentView
+                    .padding(20.0)
+                    .glassEffect(.regular.interactive(),
+                                 in: .rect(cornerRadius: 20.0))
+                    .padding(.all, 24.0)
+            } else {
+                contentView
+                    .padding()
+                    .background(.thickMaterial)
+                    .clipShape(.rect(cornerRadius: 16.0))
+                    .padding(.all, 32.0)
             }
-            .background(.thickMaterial)
-            .clipShape(.rect(cornerRadius: 16.0))
-            .padding(.all, 32.0)
         }
         .ignoresSafeArea(.all)
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        VStack(alignment: .center, spacing: 10.0) {
+            Text(LocalizedStringKey(title))
+                .bold()
+                .multilineTextAlignment(.center)
+            ProgressView(value: min(Float(percentage), 100.0), total: 100.0)
+                .progressViewStyle(.linear)
+            Text(NSLocalizedString(message, comment: "")
+                .replacingOccurrences(of: "%1", with: String(percentage)))
+            .font(.subheadline)
+            .multilineTextAlignment(.center)
+        }
     }
 }
 

--- a/DJDX/Views/UnifiedView+Backup.swift
+++ b/DJDX/Views/UnifiedView+Backup.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 extension UnifiedView {
+    func hasExistingPlayData() async -> Bool {
+        if await !IIDXReader().allImportGroups().isEmpty { return true }
+        if await SDVXReader().latestImportGroupID() != nil { return true }
+        if await PolarisChordReader().latestImportGroupID() != nil { return true }
+        return false
+    }
+
     func restoreFromBackup() {
         migrationProgress.show(
             title: "ICloudBackup.Restore.ProgressTitle",

--- a/DJDX/Views/UnifiedView+Backup.swift
+++ b/DJDX/Views/UnifiedView+Backup.swift
@@ -8,7 +8,7 @@ extension UnifiedView {
         )
         Task {
             do {
-                try await ICloudBackupManager.restore { percentage in
+                try await ICloudBackupManager.restore { [migrationProgress] percentage in
                     Task { @MainActor in
                         migrationProgress.updateProgress(percentage)
                     }

--- a/DJDX/Views/UnifiedView+Backup.swift
+++ b/DJDX/Views/UnifiedView+Backup.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+extension UnifiedView {
+    func restoreFromBackup() {
+        migrationProgress.show(
+            title: "ICloudBackup.Restore.ProgressTitle",
+            message: "ICloudBackup.Restore.ProgressMessage"
+        )
+        Task {
+            do {
+                try await ICloudBackupManager.restore { percentage in
+                    Task { @MainActor in
+                        migrationProgress.updateProgress(percentage)
+                    }
+                }
+                hasCompletedRestorePrompt = true
+                migrationProgress.hide()
+                try? await Task.sleep(for: .seconds(0.75))
+                isBackupRestoreCompleted = true
+            } catch {
+                migrationProgress.hide()
+                try? await Task.sleep(for: .seconds(0.75))
+                isBackupRestoreFailed = true
+            }
+        }
+    }
+}

--- a/DJDX/Views/UnifiedView+Migration.swift
+++ b/DJDX/Views/UnifiedView+Migration.swift
@@ -1,4 +1,3 @@
-import SwiftData
 import SwiftUI
 import UIKit
 
@@ -21,111 +20,13 @@ extension UnifiedView {
 #endif
 
     func migrateData() async {
-        let defaults = UserDefaults.standard
-        let dataMigrationKeys = [
-            "Internal.DataMigrationForEpolisToPinkyCrush.2",
-            "Internal.DataMigrationForSwiftDataToSQLite",
-            "Internal.BEMANIWikiMigratedToSeparateDB"
-        ]
-
-        UIApplication.shared.isIdleTimerDisabled = true
-        for dataMigrationKey in dataMigrationKeys where !defaults.bool(forKey: dataMigrationKey) {
-            switch dataMigrationKey {
-            case "Internal.DataMigrationForEpolisToPinkyCrush.2":
-                debugPrint("Performing migration when migrating from 1.x to 32.x")
-                migrationProgress.show(
-                    title: "Migration.Title",
-                    message: "Migration.Description"
-                )
-                let importGroups = try? modelContext.fetch(FetchDescriptor<ImportGroup>())
-                for importGroup in importGroups ?? [] where importGroup.iidxVersion == nil {
-                    importGroup.iidxVersion = .epolis
-                }
-                migrationProgress.hide()
-            case "Internal.DataMigrationForSwiftDataToSQLite":
-                await migrateSwiftDataToSQLite()
-            case "Internal.BEMANIWikiMigratedToSeparateDB":
-                let migrationImporter = IIDXImporter()
-                await migrationImporter.migrateBEMANIWikiDataIfNeeded()
-            default: break
-            }
-            UserDefaults.standard.set(true, forKey: dataMigrationKey)
-        }
-        UIApplication.shared.isIdleTimerDisabled = false
-    }
-
-    func migrateSwiftDataToSQLite() async {
-        debugPrint("Performing migration from SwiftData to SQLite")
-
-        // Fetch all SwiftData ImportGroups
-        let importGroups: [ImportGroup] = (try? modelContext.fetch(
-            FetchDescriptor<ImportGroup>(
-                sortBy: [SortDescriptor(\.importDate, order: .forward)]
-            )
-        )) ?? []
-
-        // If no data, skip migration
-        guard !importGroups.isEmpty else {
-            debugPrint("No SwiftData data to migrate")
-            UserDefaults.standard.set(true, forKey: "Internal.DataMigrationDeleteOldSQLiteData")
-            return
-        }
-
-        // Fetch songs and tower entries
-        let songs: [IIDXSong] = (try? modelContext.fetch(
-            FetchDescriptor<IIDXSong>()
-        )) ?? []
-        let towerEntries: [IIDXTowerEntry] = (try? modelContext.fetch(
-            FetchDescriptor<IIDXTowerEntry>()
-        )) ?? []
-
-        let totalGroups = importGroups.count
-
-        await MainActor.run {
-            migrationProgress.show(
-                title: "Migration.Title",
-                message: "Migration.Description"
-            )
-        }
-
-        // Small delay to allow the alert to appear
-        try? await Task.sleep(for: .milliseconds(500))
-
-        let importer = IIDXImporter()
-
-        // Migrate ImportGroups and their song records
-        for (index, importGroup) in importGroups.enumerated() {
-            await importer.migrateImportGroup(
-                importGroup,
-                songRecords: importGroup.iidxData ?? []
-            )
-
-            let progress = ((index + 1) * 100) / totalGroups
-            await MainActor.run {
-                migrationProgress.updateProgress(progress)
-            }
-        }
-
-        // Migrate IIDXSong data
-        await importer.migrateSongs(songs)
-
-        // Migrate IIDXTowerEntry data
-        await importer.migrateTowerEntries(towerEntries)
-
-        // Delete all SwiftData entries after successful migration
-        #if DEBUG
-        debugPrint("Deleting SwiftData entries after migration")
-        try? modelContext.delete(model: IIDXSongRecord.self)
-        try? modelContext.delete(model: ImportGroup.self)
-        try? modelContext.delete(model: IIDXSong.self)
-        try? modelContext.delete(model: IIDXTowerEntry.self)
-        try? modelContext.save()
-        #endif
-
-        debugPrint("Migration from SwiftData to SQLite completed")
-        await MainActor.run {
-            migrationProgress.hide()
-            NotificationCenter.default.post(name: .dataMigrationCompleted, object: nil)
+        let bemaniWikiMigrationKey = "Internal.BEMANIWikiMigratedToSeparateDB"
+        if !UserDefaults.standard.bool(forKey: bemaniWikiMigrationKey) {
+            UIApplication.shared.isIdleTimerDisabled = true
+            let migrationImporter = IIDXImporter()
+            await migrationImporter.migrateBEMANIWikiDataIfNeeded()
+            UserDefaults.standard.set(true, forKey: bemaniWikiMigrationKey)
+            UIApplication.shared.isIdleTimerDisabled = false
         }
     }
 }

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -171,11 +171,15 @@ struct UnifiedView: View {
                 hasReviewBeenPrompted = true
             }
             if !hasCompletedRestorePrompt {
-                let backupDate = await ICloudBackupManager.existingBackupDate()
-                // Re-check: the user may have made their own backup while the check was in flight.
-                if let backupDate, !hasCompletedRestorePrompt {
-                    availableBackupDate = backupDate
-                    isPromptingBackupRestore = true
+                if await hasExistingPlayData() {
+                    hasCompletedRestorePrompt = true
+                } else {
+                    let backupDate = await ICloudBackupManager.existingBackupDate()
+                    // Re-check: the user may have made their own backup while the check was in flight.
+                    if let backupDate, !hasCompletedRestorePrompt {
+                        availableBackupDate = backupDate
+                        isPromptingBackupRestore = true
+                    }
                 }
             }
         }

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -170,10 +170,13 @@ struct UnifiedView: View {
                 requestReview()
                 hasReviewBeenPrompted = true
             }
-            if !hasCompletedRestorePrompt,
-               let backupDate = await ICloudBackupManager.existingBackupDate() {
-                availableBackupDate = backupDate
-                isPromptingBackupRestore = true
+            if !hasCompletedRestorePrompt {
+                let backupDate = await ICloudBackupManager.existingBackupDate()
+                // Re-check: the user may have made their own backup while the check was in flight.
+                if let backupDate, !hasCompletedRestorePrompt {
+                    availableBackupDate = backupDate
+                    isPromptingBackupRestore = true
+                }
             }
         }
         .alert("Alert.ICloudBackup.Restore.Title", isPresented: $isPromptingBackupRestore) {

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -1,12 +1,10 @@
 import StoreKit
-import SwiftData
 import SwiftUI
 import TipKit
 
 struct UnifiedView: View {
 
     @Environment(\.requestReview) var requestReview
-    @Environment(\.modelContext) var modelContext
 
     @EnvironmentObject var navigationManager: NavigationManager
 

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -21,10 +21,17 @@ struct UnifiedView: View {
 
     @AppStorage(wrappedValue: false, "Review.IsPrompted", store: .standard) var hasReviewBeenPrompted: Bool
     @AppStorage(wrappedValue: 0, "Review.LaunchCount", store: .standard) var launchCount: Int
+    @AppStorage(wrappedValue: false, ICloudBackupManager.restorePromptCompletedKey)
+    var hasCompletedRestorePrompt: Bool
 
     @State var isPresentingImport: Bool = false
     @State var isFirstStartCleanupComplete: Bool = false
     @State var isEditingAnalytics: Bool = false
+
+    @State var availableBackupDate: Date?
+    @State var isPromptingBackupRestore: Bool = false
+    @State var isBackupRestoreCompleted: Bool = false
+    @State var isBackupRestoreFailed: Bool = false
 
     @State var migrationProgress = ProgressReporter()
 
@@ -165,6 +172,35 @@ struct UnifiedView: View {
                 requestReview()
                 hasReviewBeenPrompted = true
             }
+            if !hasCompletedRestorePrompt,
+               let backupDate = await ICloudBackupManager.existingBackupDate() {
+                availableBackupDate = backupDate
+                isPromptingBackupRestore = true
+            }
+        }
+        .alert("Alert.ICloudBackup.Restore.Title", isPresented: $isPromptingBackupRestore) {
+            Button("Alert.ICloudBackup.Restore.Confirm") {
+                restoreFromBackup()
+            }
+            Button("Alert.ICloudBackup.Restore.Decline", role: .cancel) {
+                hasCompletedRestorePrompt = true
+            }
+        } message: {
+            Text("Alert.ICloudBackup.Restore.Subtitle.\(availableBackupDate ?? .now, format: .dateTime)")
+        }
+        .alert("Alert.ICloudBackup.RestoreCompleted.Title", isPresented: $isBackupRestoreCompleted) {
+            Button("Shared.OK", role: .cancel) {
+                isBackupRestoreCompleted = false
+            }
+        } message: {
+            Text("Alert.ICloudBackup.RestoreCompleted.Subtitle")
+        }
+        .alert("Alert.ICloudBackup.RestoreFailed.Title", isPresented: $isBackupRestoreFailed) {
+            Button("Shared.OK", role: .cancel) {
+                isBackupRestoreFailed = false
+            }
+        } message: {
+            Text("Alert.ICloudBackup.RestoreFailed.Subtitle")
         }
     }
 

--- a/DJDX/Views/beatmania IIDX/Imports/IIDXImportView.swift
+++ b/DJDX/Views/beatmania IIDX/Imports/IIDXImportView.swift
@@ -136,9 +136,6 @@ struct IIDXImportView: View {
                     Task { await reloadImportGroups() }
                 }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .dataMigrationCompleted)) { _ in
-                Task { await reloadImportGroups() }
-            }
             .sheet(isPresented: $isSelectingCSVFile) {
                 DocumentPicker(allowedUTIs: [.commaSeparatedText], onDocumentPicked: { urls in
                     importCSVs(from: urls)

--- a/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
@@ -324,10 +324,6 @@ struct IIDXScoresView<Header: View>: View {
                     reloadDisplay()
                 }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .dataMigrationCompleted)) { _ in
-                dataState = .initializing
-                reloadDisplay()
-            }
             .onReceive(NotificationCenter.default.publisher(for: .dataImported)) { _ in
                 dataState = .initializing
                 reloadDisplay()

--- a/DJDX/Views/beatmania IIDX/Tower/TowerBarChart.swift
+++ b/DJDX/Views/beatmania IIDX/Tower/TowerBarChart.swift
@@ -6,37 +6,41 @@ struct TowerBarChart: View {
     var usesDateAxis: Bool = true
 
     var body: some View {
-        Chart(Array(entries.enumerated()), id: \.element.playDate) { index, entry in
+        Group {
             if usesDateAxis {
-                BarMark(
-                    x: .value("Tower.Header.PlayDate",
-                              entry.playDate, unit: .day),
-                    y: .value("Shared.IIDX.Keys", entry.keyCount)
-                )
-                .foregroundStyle(.blue)
-                .position(by: .value("Tower.Type", "Keys"))
+                Chart(entries, id: \.playDate) { entry in
+                    BarMark(
+                        x: .value("Tower.Header.PlayDate",
+                                  entry.playDate, unit: .day),
+                        y: .value("Shared.IIDX.Keys", entry.keyCount)
+                    )
+                    .foregroundStyle(.blue)
+                    .position(by: .value("Tower.Type", "Keys"))
 
-                BarMark(
-                    x: .value("Tower.Header.PlayDate",
-                              entry.playDate, unit: .day),
-                    y: .value("Shared.IIDX.Scratch", entry.scratchCount)
-                )
-                .foregroundStyle(.red)
-                .position(by: .value("Tower.Type", "Scratch"))
+                    BarMark(
+                        x: .value("Tower.Header.PlayDate",
+                                  entry.playDate, unit: .day),
+                        y: .value("Shared.IIDX.Scratch", entry.scratchCount)
+                    )
+                    .foregroundStyle(.red)
+                    .position(by: .value("Tower.Type", "Scratch"))
+                }
             } else {
-                BarMark(
-                    x: .value("Tower.Header.PlayDate", index),
-                    y: .value("Shared.IIDX.Keys", entry.keyCount)
-                )
-                .foregroundStyle(.blue)
-                .position(by: .value("Tower.Type", "Keys"))
+                Chart(Array(entries.enumerated()), id: \.element.playDate) { index, entry in
+                    BarMark(
+                        x: .value("Tower.Header.PlayDate", index),
+                        y: .value("Shared.IIDX.Keys", entry.keyCount)
+                    )
+                    .foregroundStyle(.blue)
+                    .position(by: .value("Tower.Type", "Keys"))
 
-                BarMark(
-                    x: .value("Tower.Header.PlayDate", index),
-                    y: .value("Shared.IIDX.Scratch", entry.scratchCount)
-                )
-                .foregroundStyle(.red)
-                .position(by: .value("Tower.Type", "Scratch"))
+                    BarMark(
+                        x: .value("Tower.Header.PlayDate", index),
+                        y: .value("Shared.IIDX.Scratch", entry.scratchCount)
+                    )
+                    .foregroundStyle(.red)
+                    .position(by: .value("Tower.Type", "Scratch"))
+                }
             }
         }
         .chartXScale(range: .plotDimension(startPadding: 8.0, endPadding: 8.0))

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -325,6 +325,176 @@
         }
       }
     },
+    "Alert.ICloudBackup.Failed.Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your data could not be backed up to iCloud. Check that you are signed in to iCloud, then try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudへのバックアップに失敗しました。iCloudにサインインしていることを確認して、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.Failed.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックアップに失敗しました"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.Restore.Confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.Restore.Decline" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't Restore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元しない"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.Restore.Subtitle.%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A backup created on %@ was found in iCloud. Do you want to restore it?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@に作成されたバックアップがiCloudで見つかりました。復元しますか？"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.Restore.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore From iCloud Backup?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudバックアップから復元しますか？"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.RestoreCompleted.Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart the app to finish restoring your data."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元を完了するには、アプリを再起動してください。"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.RestoreCompleted.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Completed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元が完了しました"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.RestoreFailed.Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your data could not be restored from iCloud. You can try again the next time you open the app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudからの復元に失敗しました。次回アプリ起動時に、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "Alert.ICloudBackup.RestoreFailed.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元に失敗しました"
+          }
+        }
+      }
+    },
     "Alert.Import.Error.Subtitle.Maintenance" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1292,6 +1462,142 @@
     "Height" : {
       "shouldTranslate" : false
     },
+    "ICloudBackup.BackUpNow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back Up Now"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐバックアップ"
+          }
+        }
+      }
+    },
+    "ICloudBackup.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your data will be backed up to iCloud every night at midnight."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎晩0時にデータがiCloudにバックアップされます。"
+          }
+        }
+      }
+    },
+    "ICloudBackup.Enable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back Up Automatically"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動バックアップ"
+          }
+        }
+      }
+    },
+    "ICloudBackup.LastBackup" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前回のバックアップ"
+          }
+        }
+      }
+    },
+    "ICloudBackup.LastBackup.Never" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Never"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
+        }
+      }
+    },
+    "ICloudBackup.Restore.ProgressMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring your data from iCloud. This may take a while."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudからデータを復元しています。しばらくお待ちください。"
+          }
+        }
+      }
+    },
+    "ICloudBackup.Restore.ProgressTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restoring Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックアップを復元中"
+          }
+        }
+      }
+    },
+    "ICloudBackup.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudバックアップ"
+          }
+        }
+      }
+    },
     "Importer.CSV.Backup.Button" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2142,6 +2448,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "データ管理"
+          }
+        }
+      }
+    },
+    "More.ManageData.ICloudBackup" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudバックアップ"
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds support for automatic iCloud backups that run every night at midnight, with a restore prompt on fresh installs. Also removes the deprecated SwiftData layer and bumps the version to 33.4.

### Settings sheet
- New **iCloud Backup** entry in the ellipsis menu's Data Management section, above the delete options, opening a sheet.
- The sheet shows an on/off toggle (default off). When on, it shows the last backup date (or "Never") and a **Back Up Now** button.

### Backup
- The entire local Documents folder (including backed-up CSV files and `PlayData.db`) is zipped and uploaded to the iCloud container at `Documents/Backup/Data.zip`, alongside a `LastBackup` file containing an ISO 8601 timestamp.
- Backups are entirely file-based: the database file is copied as-is, with no DB connections or queries involved.
- A `BGProcessingTask` (`com.tsubuzaki.DJDX.iCloudBackup`) is scheduled for the next midnight whenever backups are enabled, and reschedules itself after each run. `processing` was added to `UIBackgroundModes` and the identifier to `BGTaskSchedulerPermittedIdentifiers`.

### Restore
- On launch, if the restore prompt has never been completed (i.e. a fresh install) and a backup exists in iCloud, the user is prompted to restore, with the backup creation time shown in the alert.
- Restoring downloads `Data.zip`, extracts it over the Documents folder with progress shown via the existing `ProgressCard`, and asks the user to restart the app.
- Enabling backups or completing a backup marks the prompt as completed, so users are never prompted to restore their own backup.

### SwiftData removal (33.4)
- The old SwiftData → SQLite migration is deprecated and removed, along with the Epolis version-stamping migration; the BEMANIWiki database split migration is kept.
- `ImportGroup`, `IIDXSongRecord`, `IIDXSong`, `IIDXTowerEntry`, `SDVXSongRecord`, and `PolarisChordSongRecord` are no longer SwiftData `@Model` classes — they're plain classes with explicit `Hashable`/`Equatable` implementations consistent with their existing `==` semantics.
- The model container, `modelContext` usage, migration-only relationship properties (`ImportGroup.iidxData`, `IIDXSongRecord.importGroup`), the importer's migration helpers, and the now-unused `dataMigrationCompleted` notification are all removed.
- `MARKETING_VERSION` bumped from 33.3.2 to 33.4.

### Other fixes
- `TowerBarChart` now branches at the view level instead of inside the chart content builder; the newer SDK gates `_ConditionalContent`'s `ChartContent` conformance to iOS 27, which broke the build for earlier targets (this also unblocks `main` when rebuilt with the current Xcode Cloud toolchain).

### Implementation notes
- No new dependencies: zips are created with `NSFileCoordinator`'s `.forUploading` option, and extracted with a minimal ZIP central-directory reader built on the `Compression` framework (`ZipArchive.swift`), in line with the existing hand-rolled gunzip extension. The parsing logic was validated against real deflate archives.
- Per the requirement to back up only the Documents folder, the (now removed) SwiftData store in Application Support is not included; CSV files and `PlayData.db` in Documents are.
- New strings localized in English and Japanese.

https://claude.ai/code/session_01Qoy4i9Y4LtKK4SZVqa5WUk