### PR TITLE
Match trailing padding of score rows with IIDX row

### DIFF
--- a/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
+++ b/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
@@ -64,6 +64,6 @@ struct DDRScoreRow: View {
             .padding([.top, .bottom], 8.0)
         }
         .frame(maxWidth: .infinity)
-        .padding([.trailing], 20.0)
+        .padding(.trailing)
     }
 }

--- a/DJDX/Views/Polaris Chord/Scores/PolarisChordScoreRow.swift
+++ b/DJDX/Views/Polaris Chord/Scores/PolarisChordScoreRow.swift
@@ -68,6 +68,6 @@ struct PolarisChordScoreRow: View {
             .padding([.top, .bottom], 8.0)
         }
         .frame(maxWidth: .infinity)
-        .padding([.trailing], 20.0)
+        .padding(.trailing)
     }
 }

--- a/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreRow.swift
+++ b/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreRow.swift
@@ -67,6 +67,6 @@ struct SDVXScoreRow: View {
             .padding([.top, .bottom], 8.0)
         }
         .frame(maxWidth: .infinity)
-        .padding([.trailing], 20.0)
+        .padding(.trailing)
     }
 }


### PR DESCRIPTION
## Summary

Aligns the horizontal trailing edge padding of the DDR, SDVX, and Polaris Chord score rows with the IIDX score row.

The IIDX row uses `.padding(.trailing)` (the default ~16pt), while the other three rows hardcoded `.padding([.trailing], 20.0)`. This changes those three to use `.padding(.trailing)` so all four score rows share the same trailing edge inset.

## Changes

- `DDRScoreRow.swift`: `.padding([.trailing], 20.0)` → `.padding(.trailing)`
- `SDVXScoreRow.swift`: `.padding([.trailing], 20.0)` → `.padding(.trailing)`
- `PolarisChordScoreRow.swift`: `.padding([.trailing], 20.0)` → `.padding(.trailing)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyLJK5oTvVfbbvuxJSVLLy)_