### PR TITLE
Sessions/Watch fixes & OCR, DDR support (#109), and filter level grid (#110)

### DIFF
--- a/DJDX CHARGE/WatchRadarChartView.swift
+++ b/DJDX CHARGE/WatchRadarChartView.swift
@@ -162,7 +162,8 @@ struct WatchRadarChartView: View {
 
     private var color: Color {
         let sum = data.sum
-        if sum > 600.0 { return .purple
+        if sum > 800.0 { return .green
+        } else if sum > 600.0 { return .purple
         } else if sum > 400.0 { return .red
         } else if sum > 200.0 { return .yellow
         } else { return .cyan }

--- a/DJDX CHARGE/WatchWorkoutManager.swift
+++ b/DJDX CHARGE/WatchWorkoutManager.swift
@@ -55,8 +55,13 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         let read: Set = [HKQuantityType(.heartRate), HKQuantityType(.activeEnergyBurned)]
         nonisolated(unsafe) let manager = self
         healthStore.requestAuthorization(toShare: share, read: read) { success, _ in
-            guard success else { return }
-            Task { @MainActor in manager.beginWorkoutCollection() }
+            Task { @MainActor in
+                if success {
+                    manager.beginWorkoutCollection()
+                } else {
+                    manager.failWorkoutStart()
+                }
+            }
         }
     }
 
@@ -80,8 +85,24 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             builder.beginCollection(withStart: start) { _, _ in }
             isCollecting = true
         } catch {
-            return
+            failWorkoutStart()
         }
+    }
+
+    private func failWorkoutStart() {
+        guard isRunning else { return }
+        if let sessionID {
+            sendToPhone(["command": "endSession", "sessionID": sessionID])
+        }
+        session = nil
+        builder = nil
+        sessionID = nil
+        isRunning = false
+        isPaused = false
+        isCollecting = false
+        startDate = nil
+        pausedElapsed = 0
+        resetSessionInfo()
     }
 
     func pauseWorkout() {
@@ -92,8 +113,16 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         requestPause(false)
     }
 
-    fileprivate func setPaused(_ paused: Bool) {
+    fileprivate func setPaused(_ paused: Bool, sessionID: String) {
+        guard sessionID.isEmpty || sessionID == self.sessionID else { return }
         requestPause(paused)
+    }
+
+    fileprivate func adoptSession(_ newID: String) {
+        guard isRunning, !newID.isEmpty, newID != sessionID else { return }
+        sessionID = newID
+        sendWorkoutState()
+        ingest(heartRate: nil, activeCalories: nil)
     }
 
     // Only issue transitions that are valid from the session's current state —
@@ -218,12 +247,16 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     }
 
     fileprivate func applyProfile(_ context: [String: Any]) {
-        if let djName = context["djName"] as? String { self.djName = djName }
-        if let spRank = context["spRank"] as? String { self.spRank = spRank }
-        if let dpRank = context["dpRank"] as? String { self.dpRank = dpRank }
-        if let values = context["spRadar"] as? [Double] { spRadar = WatchRadarData(values: values) }
-        if let values = context["dpRadar"] as? [Double] { dpRadar = WatchRadarData(values: values) }
-        if let qpro = context["qpro"] as? Data { qproImageData = qpro }
+        if let djName = context["djName"] as? String { self.djName = djName.isEmpty ? nil : djName }
+        if let spRank = context["spRank"] as? String { self.spRank = spRank.isEmpty ? nil : spRank }
+        if let dpRank = context["dpRank"] as? String { self.dpRank = dpRank.isEmpty ? nil : dpRank }
+        if let values = context["spRadar"] as? [Double] {
+            spRadar = values.isEmpty ? nil : WatchRadarData(values: values)
+        }
+        if let values = context["dpRadar"] as? [Double] {
+            dpRadar = values.isEmpty ? nil : WatchRadarData(values: values)
+        }
+        if let qpro = context["qpro"] as? Data { qproImageData = qpro.isEmpty ? nil : qpro }
         persistComplicationRadar(context)
     }
 
@@ -231,11 +264,13 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         guard let shared = UserDefaults(suiteName: "group.com.tsubuzaki.DJDX") else { return }
         var changed = false
         if let sp = context["spRadar"] as? [Double] {
-            shared.set(sp, forKey: "Watch.Complication.RadarSP")
+            if sp.isEmpty { shared.removeObject(forKey: "Watch.Complication.RadarSP") }
+            else { shared.set(sp, forKey: "Watch.Complication.RadarSP") }
             changed = true
         }
         if let dp = context["dpRadar"] as? [Double] {
-            shared.set(dp, forKey: "Watch.Complication.RadarDP")
+            if dp.isEmpty { shared.removeObject(forKey: "Watch.Complication.RadarDP") }
+            else { shared.set(dp, forKey: "Watch.Complication.RadarDP") }
             changed = true
         }
         if changed {
@@ -264,14 +299,19 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         switch command {
         case "start": activateSession(sessionID: sessionID)
         case "end": endWorkout()
+        case "adoptSession": adoptSession(sessionID)
+        case "requestWorkoutState": if isRunning { sendWorkoutState() }
         default: break
         }
     }
 
     private func sendToPhone(_ payload: [String: Any]) {
         let connectivity = WCSession.default
+        guard connectivity.activationState == .activated else { return }
         if connectivity.isReachable {
-            connectivity.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+            connectivity.sendMessage(payload, replyHandler: nil) { _ in
+                connectivity.transferUserInfo(payload)
+            }
         } else {
             connectivity.transferUserInfo(payload)
         }
@@ -288,7 +328,10 @@ extension WatchWorkoutManager: HKWorkoutSessionDelegate {
     }
 
     nonisolated func workoutSession(_ workoutSession: HKWorkoutSession,
-                                    didFailWithError error: Error) {}
+                                    didFailWithError error: Error) {
+        nonisolated(unsafe) let manager = self
+        Task { @MainActor in manager.requestEndSession() }
+    }
 }
 
 extension WatchWorkoutManager: HKLiveWorkoutBuilderDelegate {
@@ -347,12 +390,12 @@ extension WatchWorkoutManager: WCSessionDelegate {
     private nonisolated func route(_ message: [String: Any]) {
         nonisolated(unsafe) let manager = self
         if let command = message["command"] as? String {
+            let sessionID = message["sessionID"] as? String ?? ""
             if command == "setPaused" {
                 let paused = message["paused"] as? Bool ?? false
-                Task { @MainActor in manager.setPaused(paused) }
+                Task { @MainActor in manager.setPaused(paused, sessionID: sessionID) }
                 return
             }
-            let sessionID = message["sessionID"] as? String ?? ""
             Task { @MainActor in manager.handleCommand(command, sessionID: sessionID) }
             return
         }

--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -858,7 +858,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.DJDX.watchkitapp.DJDX-CHARGE-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -891,7 +891,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.DJDX.watchkitapp.DJDX-CHARGE-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/DJDX/Classes/ICloudBackupManager.swift
+++ b/DJDX/Classes/ICloudBackupManager.swift
@@ -98,6 +98,24 @@ enum ICloudBackupManager {
         UserDefaults.standard.set(true, forKey: restorePromptCompletedKey)
     }
 
+    // MARK: Export
+
+    static func exportArchive() async -> URL? {
+        await Task.detached(priority: .userInitiated) { () -> URL? in
+            do {
+                let fileManager = FileManager.default
+                let exportDirectory = fileManager.temporaryDirectory
+                    .appendingPathComponent("Export-\(UUID().uuidString)", isDirectory: true)
+                try fileManager.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+                let archiveURL = exportDirectory.appendingPathComponent("DJDX Backup.zip")
+                try ZipArchive.zip(directoryAt: SharedContainer.containerURL, to: archiveURL)
+                return archiveURL
+            } catch {
+                return nil
+            }
+        }.value
+    }
+
     // MARK: Restore
 
     static func existingBackupDate() async -> Date? {

--- a/DJDX/Games/Dance Dance Revolution/Data Types/DDRSongRecord.swift
+++ b/DJDX/Games/Dance Dance Revolution/Data Types/DDRSongRecord.swift
@@ -111,10 +111,6 @@ final class DDRSongRecord: Equatable, Hashable, @unchecked Sendable {
         clearKind.uppercased()
     }
 
-    var levelText: String {
-        level > 0 ? String(level) : "?"
-    }
-
     func titleCompact() -> String {
         title.ddrCompact
     }

--- a/DJDX/Games/Dance Dance Revolution/Data Types/DDRSongRecord.swift
+++ b/DJDX/Games/Dance Dance Revolution/Data Types/DDRSongRecord.swift
@@ -45,7 +45,7 @@ final class DDRSongRecord: Equatable, Hashable, @unchecked Sendable {
     }
 
     static let clearLampOrder: [String] = [
-        "marv", "perf", "great", "good", "life4", "clear", "assist", "fail"
+        "marv", "perf", "great", "good", "li4clear", "clear", "assist", "fail"
     ]
 
     static let noClearKey = "noclear"
@@ -85,7 +85,7 @@ final class DDRSongRecord: Equatable, Hashable, @unchecked Sendable {
         case "perf": Color(red: 1.0, green: 0.82, blue: 0.0)
         case "great": .green
         case "good": Color(red: 0.2, green: 0.55, blue: 1.0)
-        case "life4": .red
+        case "li4clear": .red
         case "clear": Color(red: 0.0, green: 0.8, blue: 0.5)
         case "assist": .purple
         case "fail": .gray

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXPlaySessionsDatabase.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXPlaySessionsDatabase.swift
@@ -59,11 +59,15 @@ final class IIDXPlaySessionsDatabase: Sendable {
     }
 
     func getReadConnection() throws -> Connection {
-        try Connection(databasePath, readonly: true)
+        let connection = try Connection(databasePath, readonly: true)
+        connection.busyTimeout = 5.0
+        return connection
     }
 
     func getWriteConnection() throws -> Connection {
-        try Connection(databasePath)
+        let connection = try Connection(databasePath)
+        connection.busyTimeout = 5.0
+        return connection
     }
 
     // swiftlint:disable:next function_body_length
@@ -155,11 +159,17 @@ final class IIDXPlaySessionsDatabase: Sendable {
         ))
     }
 
-    func endSession(id: String, endDate: Date = .now) {
-        guard let database = try? getWriteConnection() else { return }
-        try? database.run(Self.sessionTable.filter(Self.sID == id).update(
-            Self.sEndDate <- endDate.timeIntervalSince1970
-        ))
+    @discardableResult
+    func endSession(id: String, endDate: Date = .now) -> Bool {
+        guard let database = try? getWriteConnection() else { return false }
+        do {
+            try database.run(Self.sessionTable.filter(Self.sID == id).update(
+                Self.sEndDate <- endDate.timeIntervalSince1970
+            ))
+            return true
+        } catch {
+            return false
+        }
     }
 
     func deleteSession(id: String) {

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXResultParser.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXResultParser.swift
@@ -97,35 +97,38 @@ enum IIDXResultParser {
             parse.miss = value
             hits += 1
         }
-        var perfectGreat = headlineNumber(text("judge_pgreat"))
-        var great = headlineNumber(text("judge_great"))
-        reconcileJudges(exScore: parse.exScore, perfectGreat: &perfectGreat, great: &great)
+        let pgRead = headlineNumber(text("judge_pgreat"))
+        let greatRead = headlineNumber(text("judge_great"))
+        var perfectGreat = pgRead
+        var great = greatRead
+        reconcileJudges(exScore: parse.exScore, notes: notes, perfectGreat: &perfectGreat, great: &great)
         if let perfectGreat { parse.perfectGreat = perfectGreat; hits += 1 }
         if let great { parse.great = great; hits += 1 }
         if let value = headlineNumber(text("judge_good")) { parse.good = value }
         if let value = headlineNumber(text("judge_bad")) { parse.bad = value }
         if let value = headlineNumber(text("judge_poor")) { parse.poor = value }
 
-        // The DJ grade is defined by the score rate (exScore / max), so derive it
-        // directly whenever the notes count is known — that is authoritative and
-        // avoids the rank classifier's occasional misreads (e.g. a spurious "F").
-        // Fall back to IIDXRankRecognizer's classification of the dj_level_now
-        // graphic only when the notes count is missing.
-        if let derived = derivedDJLevel(exScore: parse.exScore, notes: notes) {
+        let classifiedDJLevel = text("dj_level_now").flatMap(gradeOf)
+        var djLevelConflict = false
+        if let notes, notesArePlausible(notes: notes, parse: parse),
+           let derived = derivedDJLevel(exScore: parse.exScore, notes: notes) {
             parse.djLevel = derived
             hits += 1
-        } else if let value = text("dj_level_now").flatMap(gradeOf) {
-            parse.djLevel = value
+            if let classifiedDJLevel, gradeDistance(classifiedDJLevel, derived) > 1 {
+                djLevelConflict = true
+            }
+        } else if let classifiedDJLevel {
+            parse.djLevel = classifiedDJLevel
             hits += 1
         }
 
         var bonus = 0.0
-        if parse.exScore > 0,
-           parse.perfectGreat > 0 || parse.great > 0,
+        if parse.exScore > 0, pgRead != nil, greatRead != nil,
            parse.exScore == 2 * parse.perfectGreat + parse.great {
             bonus = 1.0
         }
         parse.confidence = min(1.0, (Double(hits) + bonus) / 8.0)
+        if djLevelConflict { parse.confidence = min(parse.confidence, 0.5) }
         return parse
     }
 
@@ -133,15 +136,38 @@ enum IIDXResultParser {
 
     // EX score = 2·perfect-great + great. The small judge fonts misread far more
     // often than the headline score, so recover a missing count from the others.
-    private static func reconcileJudges(exScore: Int, perfectGreat: inout Int?, great: inout Int?) {
+    private static func reconcileJudges(exScore: Int, notes: Int?,
+                                        perfectGreat: inout Int?, great: inout Int?) {
         guard exScore > 0 else { return }
         if let perfect = perfectGreat, great == nil {
             let derived = exScore - 2 * perfect
-            if derived >= 0 { great = derived }
+            if derived >= 0, isWithinNotes(perfect + derived, notes: notes) { great = derived }
         } else if let good = great, perfectGreat == nil {
             let remainder = exScore - good
-            if remainder >= 0, remainder % 2 == 0 { perfectGreat = remainder / 2 }
+            if remainder >= 0, remainder % 2 == 0 {
+                let perfect = remainder / 2
+                if isWithinNotes(perfect + good, notes: notes) { perfectGreat = perfect }
+            }
         }
+    }
+
+    private static func isWithinNotes(_ total: Int, notes: Int?) -> Bool {
+        guard let notes else { return true }
+        return total <= notes
+    }
+
+    private static func notesArePlausible(notes: Int, parse: IIDXResultParse) -> Bool {
+        guard notes > 0 else { return false }
+        let judged = parse.perfectGreat + parse.great + parse.good + parse.bad + parse.poor
+        return notes >= judged
+    }
+
+    private static func gradeDistance(_ lhs: String, _ rhs: String) -> Int {
+        guard let left = IIDXDJLevel(rawValue: lhs).flatMap({ IIDXDJLevel.sorted.firstIndex(of: $0) }),
+              let right = IIDXDJLevel(rawValue: rhs).flatMap({ IIDXDJLevel.sorted.firstIndex(of: $0) }) else {
+            return 0
+        }
+        return abs(left - right)
     }
 
     private static func derivedDJLevel(exScore: Int, notes: Int?) -> String? {

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXResultReader.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXResultReader.swift
@@ -8,6 +8,7 @@ struct DetectedRegion: Sendable {
     let text: String
     let box: CGRect
     let confidence: Float
+    var recognitionFailed: Bool = false
 }
 
 enum IIDXResultReaderError: Error {
@@ -73,28 +74,29 @@ enum IIDXResultReader {
 
         var regions: [DetectedRegion] = []
         for detection in detections {
-            let text = await read(detection, in: image)
+            let (text, failed) = await read(detection, in: image)
             regions.append(DetectedRegion(
                 label: detection.label,
                 text: text,
                 box: detection.box,
-                confidence: detection.confidence
+                confidence: detection.confidence,
+                recognitionFailed: failed
             ))
         }
         return regions
     }
 
-    private static func read(_ detection: RawDetection, in image: CGImage) async -> String {
-        guard let crop = crop(detection.box, from: image) else { return "" }
+    private static func read(_ detection: RawDetection, in image: CGImage) async -> (text: String, failed: Bool) {
+        guard let crop = crop(detection.box, from: image) else { return ("", false) }
         if detection.label == "dj_level_now" {
-            return await IIDXRankRecognizer.classify(cgImage: crop) ?? ""
+            return (await IIDXRankRecognizer.classify(cgImage: crop) ?? "", false)
         }
         if titleLabels.contains(detection.label) {
             return await ocrText(crop, languages: IIDXSessionTextRecognizer.titleLanguages)
         }
         if digitLabels.contains(detection.label),
            let value = await IIDXDigitRecognizer.recognize(cgImage: crop) {
-            return String(value)
+            return (String(value), false)
         }
         return await ocrText(crop, languages: IIDXSessionTextRecognizer.numericLanguages)
     }
@@ -143,15 +145,21 @@ enum IIDXResultReader {
 
     // MARK: - Per-region OCR
 
-    private static func ocrText(_ crop: CGImage, languages: [String]) async -> String {
-        let lines = (try? await IIDXSessionTextRecognizer.recognize(cgImage: crop, languages: languages)) ?? []
+    private static func ocrText(_ crop: CGImage, languages: [String]) async -> (text: String, failed: Bool) {
+        let lines: [OCRLine]
+        do {
+            lines = try await IIDXSessionTextRecognizer.recognize(cgImage: crop, languages: languages)
+        } catch {
+            return ("", true)
+        }
         // Headline value first: a field's own value is rendered larger than any
         // neighbouring delta/column that bleeds into the crop.
-        return lines
+        let text = lines
             .sorted { $0.box.height > $1.box.height }
             .map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .joined(separator: "\n")
+        return (text, false)
     }
 
     private static func crop(_ box: CGRect, from image: CGImage) -> CGImage? {

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionCaptureProcessor.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionCaptureProcessor.swift
@@ -58,7 +58,10 @@ actor IIDXSessionCaptureProcessor {
             play.apply(parse)
             play.processedAt = .now
             play.parseError = nil
-            let acceptable = parse.matchedSongID != nil && parse.confidence >= Self.acceptableConfidence
+            let recognitionFailed = regions.contains { $0.recognitionFailed }
+            let acceptable = parse.matchedSongID != nil
+                && parse.confidence >= Self.acceptableConfidence
+                && !recognitionFailed
             play.state = acceptable ? .done : .needsReview
             database.updatePlay(play)
             notify(playID)

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionLiveActivityController.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionLiveActivityController.swift
@@ -25,7 +25,12 @@ final class IIDXSessionLiveActivityController {
             gameIconAssetName: "GameIconIIDX"
         )
         let content = ActivityContent(state: contentState(for: session.id), staleDate: nil)
-        activity = try? Activity.request(attributes: attributes, content: content)
+        guard let activity = try? Activity.request(attributes: attributes, content: content) else {
+            self.activity = nil
+            sessionID = nil
+            return
+        }
+        self.activity = activity
         sessionID = session.id
     }
 

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionStore.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionStore.swift
@@ -45,7 +45,7 @@ final class IIDXSessionStore {
 
     func endSession() {
         guard let activeSession else { return }
-        database.endSession(id: activeSession.id)
+        guard database.endSession(id: activeSession.id) else { return }
         let endedID = activeSession.id
         IIDXSessionWorkoutBridge.shared.endWorkout(session: activeSession)
         self.activeSession = nil

--- a/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionWorkoutBridge.swift
+++ b/DJDX/Games/beatmania IIDX/Sessions/IIDXSessionWorkoutBridge.swift
@@ -14,15 +14,20 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
     @Published var activeCalories: Int = 0
     @Published var isWorkoutActive: Bool = false
     @Published var isPaused: Bool = false
+    @Published private(set) var runningStart: Date?
+    @Published private(set) var pausedElapsed: TimeInterval?
 
     private let healthStore = HKHealthStore()
     private let database = IIDXPlaySessionsDatabase.shared
     private var activeSessionID: String?
     private var workoutStart: Date?
+    private var watchWorkoutConfirmed = false
 
     var isEnabled: Bool {
         UserDefaults.standard.bool(forKey: Self.healthKitEnabledKey)
     }
+
+    var isSessionActive: Bool { activeSessionID != nil }
 
     private var isWatchAvailable: Bool {
         WCSession.isSupported()
@@ -86,20 +91,58 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
     }
 
     func startWorkout(session: IIDXPlaySession) {
-        guard isEnabled || isWatchAvailable else { return }
         activeSessionID = session.id
         workoutStart = session.startDate
-        isWorkoutActive = true
+        runningStart = session.startDate
+        pausedElapsed = nil
         isPaused = false
+        watchWorkoutConfirmed = false
         heartRate = 0
         activeCalories = 0
-        send(["command": "start", "sessionID": session.id])
-        launchWatchApp()
+        let hasWorkout = isEnabled || isWatchAvailable
+        isWorkoutActive = hasWorkout
+        if hasWorkout {
+            send(["command": "start", "sessionID": session.id])
+            launchWatchApp()
+        }
     }
 
     func setWorkoutPaused(_ paused: Bool) {
-        guard isWorkoutActive, let activeSessionID else { return }
-        send(["command": "setPaused", "sessionID": activeSessionID, "paused": paused])
+        guard let activeSessionID else { return }
+        let now = Date()
+        if paused {
+            guard !isPaused else { return }
+            let anchor = runningStart ?? workoutStart ?? now
+            pausedElapsed = max(0, now.timeIntervalSince(anchor))
+            isPaused = true
+        } else {
+            guard isPaused else { return }
+            runningStart = now.addingTimeInterval(-(pausedElapsed ?? 0))
+            pausedElapsed = nil
+            isPaused = false
+        }
+        IIDXSessionLiveActivityController.shared.updatePauseState(
+            sessionID: activeSessionID,
+            isPaused: isPaused,
+            pausedElapsed: isPaused ? pausedElapsed : nil,
+            runningStart: isPaused ? nil : runningStart
+        )
+        if isWorkoutActive {
+            send(["command": "setPaused", "sessionID": activeSessionID, "paused": paused])
+        }
+    }
+
+    func reconcileActiveSession() {
+        guard let session = database.activeSession(), session.isActive else { return }
+        if activeSessionID == nil {
+            activeSessionID = session.id
+            workoutStart = session.startDate
+            runningStart = runningStart ?? session.startDate
+            isWorkoutActive = isEnabled || isWatchAvailable
+        }
+        if isWorkoutActive {
+            send(["command": "requestWorkoutState", "sessionID": session.id])
+        }
     }
 
     private func launchWatchApp() {
@@ -112,7 +155,11 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = .fitnessGaming
         configuration.locationType = .indoor
-        healthStore.startWatchApp(with: configuration) { _, _ in }
+        healthStore.startWatchApp(with: configuration) { success, error in
+            if !success {
+                debugPrint("Failed to launch Watch app for session: \(String(describing: error))")
+            }
+        }
     }
 
     fileprivate func resendStartIfActive() {
@@ -122,14 +169,19 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
 
     func endWorkout(session: IIDXPlaySession) {
         guard activeSessionID == session.id else { return }
-        send(["command": "end", "sessionID": session.id])
-        if !WCSession.default.isPaired {
+        if isWorkoutActive {
+            send(["command": "end", "sessionID": session.id])
+        }
+        if isEnabled, !watchWorkoutConfirmed {
             saveFallbackWorkout(for: session)
         }
         isWorkoutActive = false
         isPaused = false
         activeSessionID = nil
         workoutStart = nil
+        runningStart = nil
+        pausedElapsed = nil
+        watchWorkoutConfirmed = false
         heartRate = 0
         activeCalories = 0
     }
@@ -138,7 +190,9 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
         let connectivity = WCSession.default
         guard connectivity.activationState == .activated else { return }
         if connectivity.isReachable {
-            connectivity.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+            connectivity.sendMessage(payload, replyHandler: nil) { _ in
+                connectivity.transferUserInfo(payload)
+            }
         } else {
             connectivity.transferUserInfo(payload)
         }
@@ -168,17 +222,17 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
     func syncProfileToWatch() {
         let connectivity = WCSession.default
         guard connectivity.activationState == .activated else { return }
-        var context: [String: Any] = [:]
         let standard = UserDefaults.standard
-        if let djName = standard.string(forKey: "Profile.IIDX.DJName") { context["djName"] = djName }
-        if let spRank = standard.string(forKey: "Profile.IIDX.SPRank") { context["spRank"] = spRank }
-        if let dpRank = standard.string(forKey: "Profile.IIDX.DPRank") { context["dpRank"] = dpRank }
         let shared = SharedContainer.defaults
-        if let spRadar = radarValues(prefix: "NotesRadar.SP", defaults: shared) { context["spRadar"] = spRadar }
-        if let dpRadar = radarValues(prefix: "NotesRadar.DP", defaults: shared) { context["dpRadar"] = dpRadar }
-        if let qpro = watchQproImageData() { context["qpro"] = qpro }
-        guard !context.isEmpty else { return }
-        context["ts"] = Date.now.timeIntervalSince1970
+        let context: [String: Any] = [
+            "djName": standard.string(forKey: "Profile.IIDX.DJName") ?? "",
+            "spRank": standard.string(forKey: "Profile.IIDX.SPRank") ?? "",
+            "dpRank": standard.string(forKey: "Profile.IIDX.DPRank") ?? "",
+            "spRadar": radarValues(prefix: "NotesRadar.SP", defaults: shared) ?? [],
+            "dpRadar": radarValues(prefix: "NotesRadar.DP", defaults: shared) ?? [],
+            "qpro": watchQproImageData() ?? Data(),
+            "ts": Date.now.timeIntervalSince1970
+        ]
         try? connectivity.updateApplicationContext(context)
     }
 
@@ -214,12 +268,14 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
               let session = database.session(id: sessionID), session.isActive else { return }
         activeSessionID = sessionID
         workoutStart = session.startDate
+        runningStart = runningStart ?? session.startDate
         isWorkoutActive = true
     }
 
     fileprivate func ingestMetrics(heartRate: Int?, activeCalories: Int?, sessionID: String) {
         adoptSessionIfNeeded(sessionID)
         guard sessionID == activeSessionID else { return }
+        watchWorkoutConfirmed = true
         if let heartRate { self.heartRate = heartRate }
         if let activeCalories { self.activeCalories = activeCalories }
         IIDXSessionLiveActivityController.shared.updateMetrics(
@@ -232,17 +288,25 @@ final class IIDXSessionWorkoutBridge: NSObject, ObservableObject {
 
     fileprivate func applyWorkoutState(sessionID: String, paused: Bool, elapsed: Double?, start: Double?) {
         adoptSessionIfNeeded(sessionID)
-        let runningStart = start.map { Date(timeIntervalSince1970: $0) }
+        guard sessionID == activeSessionID else { return }
+        watchWorkoutConfirmed = true
         isPaused = paused
+        if paused {
+            if let elapsed { pausedElapsed = elapsed }
+        } else {
+            if let start { runningStart = Date(timeIntervalSince1970: start) }
+            pausedElapsed = nil
+        }
         IIDXSessionLiveActivityController.shared.updatePauseState(
             sessionID: sessionID,
             isPaused: paused,
-            pausedElapsed: elapsed,
-            runningStart: runningStart
+            pausedElapsed: paused ? pausedElapsed : nil,
+            runningStart: paused ? nil : runningStart
         )
     }
 
     fileprivate func storeWorkoutUUID(_ uuid: String, sessionID: String) {
+        if sessionID == activeSessionID { watchWorkoutConfirmed = true }
         guard let session = database.session(id: sessionID) else { return }
         session.workoutUUID = uuid
         database.updateSession(session)
@@ -309,7 +373,13 @@ extension IIDXSessionWorkoutBridge: WCSessionDelegate {
             case "startSession":
                 let requestedID = sessionID.isEmpty ? nil : sessionID
                 Task { @MainActor in
-                    NotificationCenter.default.post(name: .startSessionRequested, object: requestedID)
+                    if let active = bridge.database.activeSession(), active.isActive,
+                       active.id != requestedID {
+                        bridge.reconcileActiveSession()
+                        bridge.send(["command": "adoptSession", "sessionID": active.id])
+                    } else {
+                        NotificationCenter.default.post(name: .startSessionRequested, object: requestedID)
+                    }
                 }
             case "endSession":
                 Task { @MainActor in

--- a/DJDX/Views/Analytics/DDRAnalyticsDestinationView.swift
+++ b/DJDX/Views/Analytics/DDRAnalyticsDestinationView.swift
@@ -16,7 +16,7 @@ struct DDRAnalyticsDestinationView: View {
                     .navigationTitle("Analytics.DDR.ClearBreakdown")
                     .automaticNavigationTransition(id: "DDR.clearBreakdown", in: namespace)
             case .rankBreakdownDetail:
-                DDRRankBreakdownDetailView(rankPerDifficulty: model.rankPerDifficulty)
+                DDRRankBreakdownDetailView(rankPerLevel: model.rankPerLevel)
                     .navigationTitle("Analytics.DDR.RankBreakdown")
                     .automaticNavigationTransition(id: "DDR.rankBreakdown", in: namespace)
             }
@@ -97,24 +97,24 @@ struct DDRClearTypeLevelRow: View {
 }
 
 struct DDRRankBreakdownDetailView: View {
-    let rankPerDifficulty: [DDRDifficulty: OrderedDictionary<String, Int>]
+    let rankPerLevel: [Int: OrderedDictionary<String, Int>]
 
-    var populatedDifficulties: [DDRDifficulty] {
-        DDRDifficulty.sorted.filter { difficulty in
-            (rankPerDifficulty[difficulty]?.values.contains(where: { $0 > 0 })) ?? false
-        }
+    var populatedLevels: [Int] {
+        rankPerLevel.filter { _, counts in
+            counts.values.contains(where: { $0 > 0 })
+        }.keys.sorted()
     }
 
     var body: some View {
         List {
-            if populatedDifficulties.isEmpty {
+            if populatedLevels.isEmpty {
                 Text("Analytics.NoData")
                     .foregroundStyle(.secondary)
                     .listRowBackground(Color.clear)
             } else {
-                ForEach(populatedDifficulties, id: \.self) { difficulty in
+                ForEach(populatedLevels, id: \.self) { level in
                     Section {
-                        Chart(rankElements(for: difficulty), id: \.key) { element in
+                        Chart(rankElements(for: level), id: \.key) { element in
                             BarMark(
                                 x: .value("Rank", DDRSongRecord.rankDisplay(forStem: element.key)),
                                 y: .value("Shared.ClearCount", element.value)
@@ -124,8 +124,7 @@ struct DDRRankBreakdownDetailView: View {
                         .frame(height: 140.0)
                         .listRowBackground(Color.clear)
                     } header: {
-                        Text(verbatim: difficulty.rawValue)
-                            .foregroundStyle(difficulty.color)
+                        Text(verbatim: "LEVEL \(level)")
                     }
                 }
             }
@@ -134,8 +133,8 @@ struct DDRRankBreakdownDetailView: View {
         .scrollContentBackground(.hidden)
     }
 
-    func rankElements(for difficulty: DDRDifficulty) -> [(key: String, value: Int)] {
-        let counts = rankPerDifficulty[difficulty] ?? [:]
+    func rankElements(for level: Int) -> [(key: String, value: Int)] {
+        let counts = rankPerLevel[level] ?? [:]
         return DDRSongRecord.rankOrder.compactMap { rank in
             let count = counts[rank] ?? 0
             return count > 0 ? (rank, count) : nil

--- a/DJDX/Views/Analytics/DDRAnalyticsModel.swift
+++ b/DJDX/Views/Analytics/DDRAnalyticsModel.swift
@@ -8,6 +8,7 @@ final class DDRAnalyticsModel {
     var clearTypePerDifficulty: [DDRDifficulty: OrderedDictionary<String, Int>] = [:]
     var rankPerDifficulty: [DDRDifficulty: OrderedDictionary<String, Int>] = [:]
     var clearTypePerLevel: [Int: OrderedDictionary<String, Int>] = [:]
+    var rankPerLevel: [Int: OrderedDictionary<String, Int>] = [:]
 
     var totalCharts: Int = 0
 
@@ -23,6 +24,7 @@ final class DDRAnalyticsModel {
         var clearByDiff: [DDRDifficulty: OrderedDictionary<String, Int>] = [:]
         var rankByDiff: [DDRDifficulty: OrderedDictionary<String, Int>] = [:]
         var clearByLevel: [Int: OrderedDictionary<String, Int>] = [:]
+        var rankByLevel: [Int: OrderedDictionary<String, Int>] = [:]
 
         let clearKeys = DDRSongRecord.clearLampOrder
         let breakdownKeys = DDRSongRecord.clearBreakdownOrder
@@ -50,6 +52,10 @@ final class DDRAnalyticsModel {
             }
             if rankKeys.contains(record.rank) {
                 rankByDiff[difficulty]?[record.rank]? += 1
+                if record.level > 0 {
+                    if rankByLevel[record.level] == nil { rankByLevel[record.level] = emptyRankCounts() }
+                    rankByLevel[record.level]?[record.rank]? += 1
+                }
             }
 
             if record.level > 0, let clearBucket {
@@ -64,6 +70,7 @@ final class DDRAnalyticsModel {
             self.clearTypePerDifficulty = clearByDiff
             self.rankPerDifficulty = rankByDiff
             self.clearTypePerLevel = clearByLevel
+            self.rankPerLevel = rankByLevel
             self.totalCharts = chartCount
             self.dataState = .presenting
         }

--- a/DJDX/Views/App.swift
+++ b/DJDX/Views/App.swift
@@ -14,6 +14,7 @@ struct DJDXApp: App {
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
                         IIDXSessionLiveActivityController.shared.reconcile()
+                        IIDXSessionWorkoutBridge.shared.reconcileActiveSession()
                     }
                 }
         }
@@ -33,6 +34,7 @@ struct DJDXApp: App {
         }
         Task { @MainActor in
             IIDXSessionLiveActivityController.shared.reconcile()
+            IIDXSessionWorkoutBridge.shared.reconcileActiveSession()
         }
         Task {
             let playTypeRaw = UserDefaults.standard.string(forKey: "ScoresView.PlayTypeFilter") ?? "single"

--- a/DJDX/Views/Dance Dance Revolution/DDRHeaderView.swift
+++ b/DJDX/Views/Dance Dance Revolution/DDRHeaderView.swift
@@ -13,6 +13,12 @@ extension UnifiedView {
             .pickerStyle(.segmented)
             .padding(.horizontal)
             .padding(.top, 8.0)
+            if !isDDRExternalDataEnabled {
+                ddrBemaniWikiWarning
+                    .padding(.horizontal)
+                    .padding(.top, 16.0)
+                    .transition(.scale(scale: 0.9).combined(with: .opacity))
+            }
             if showProfileHeader {
                 DDRProfileHeaderView()
                     .padding(.horizontal)
@@ -27,7 +33,36 @@ extension UnifiedView {
             }
         }
         .padding(.bottom, 8.0)
+        .animation(.smooth.speed(2.0), value: isDDRExternalDataEnabled)
         .animation(.smooth.speed(2.0), value: showProfileHeader)
         .animation(.smooth.speed(2.0), value: showAnalytics)
+    }
+
+    @ViewBuilder
+    var ddrBemaniWikiWarning: some View {
+        HStack(alignment: .top, spacing: 12.0) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 18.0, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36.0, height: 36.0)
+                .background(.orange, in: RoundedRectangle(cornerRadius: 9.0, style: .continuous))
+            VStack(alignment: .leading, spacing: 3.0) {
+                Text("DDR.DataSource.Warning.Title")
+                    .font(.subheadline.weight(.semibold))
+                Text("DDR.DataSource.Warning.Message")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("DDR.DataSource.Warning.Action") {
+                    navigationManager.push(MorePath.moreExternalDataSources)
+                }
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.orange)
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0.0)
+        }
+        .padding(12.0)
+        .cardBackground(cornerRadius: 8.0)
     }
 }

--- a/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreFilter.swift
+++ b/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreFilter.swift
@@ -45,13 +45,12 @@ struct DDRScoreFilterSheet: View {
                         DDRFilterDisclosureLabel("Shared.Level", count: difficultiesToShow.count)
                     }
                     DisclosureGroup {
-                        ForEach(availableLevels, id: \.self) { level in
-                            DDRSelectableRow(isSelected: levelsToShow.contains(level)) {
-                                Text(verbatim: String(level))
-                            } action: {
-                                toggle(level, in: $levelsToShow)
-                            }
-                        }
+                        FilterLevelGrid(
+                            items: availableLevels,
+                            selection: levelsToShow,
+                            title: { String($0) },
+                            onToggle: { toggle($0, in: $levelsToShow) }
+                        )
                     } label: {
                         DDRFilterDisclosureLabel("Shared.Sort.Difficulty", count: levelsToShow.count)
                     }

--- a/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
+++ b/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
@@ -6,7 +6,7 @@ struct DDRScoreRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 8.0) {
-            record.difficultyEnum.color
+            DDRSongRecord.clearColor(for: record.clearKind)
                 .frame(width: 10.0)
                 .frame(maxHeight: .infinity)
                 .conditionalShadow(.black.opacity(0.2), radius: 1.0, x: 2.0)

--- a/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
+++ b/DJDX/Views/Dance Dance Revolution/Scores/DDRScoreRow.swift
@@ -53,10 +53,12 @@ struct DDRScoreRow: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                     .foregroundStyle(record.difficultyEnum.color)
-                Text(verbatim: record.levelText)
-                    .font(.system(size: 18.0).weight(.heavy))
-                    .fontWidth(.condensed)
-                    .monospacedDigit()
+                if record.level > 0 {
+                    Text(verbatim: String(record.level))
+                        .font(.system(size: 18.0).weight(.heavy))
+                        .fontWidth(.condensed)
+                        .monospacedDigit()
+                }
             }
             .padding([.top, .bottom], 6.0)
             .frame(width: 78.0, alignment: .center)

--- a/DJDX/Views/More/MoreICloudBackup.swift
+++ b/DJDX/Views/More/MoreICloudBackup.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct MoreICloudBackup: View {
 
@@ -16,6 +17,8 @@ struct MoreICloudBackup: View {
         List {
             Section {
                 Toggle("ICloudBackup.Enable", systemImage: "icloud", isOn: $isBackupEnabled)
+            } header: {
+                Text("More.ManageData.ICloudBackup")
             } footer: {
                 Text("ICloudBackup.Description")
             }
@@ -42,8 +45,15 @@ struct MoreICloudBackup: View {
                     .disabled(isBackingUp)
                 }
             }
+            Section {
+                ShareLink(item: BackupExport(), preview: SharePreview("Backup.Title")) {
+                    Label("Backup.Export", systemImage: "square.and.arrow.up")
+                }
+            } footer: {
+                Text("Backup.Export.Footer")
+            }
         }
-        .navigationTitle("ICloudBackup.Title")
+        .navigationTitle("Backup.Title")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -89,6 +99,17 @@ struct MoreICloudBackup: View {
             if !isSuccessful {
                 isBackupFailed = true
             }
+        }
+    }
+}
+
+struct BackupExport: Transferable {
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .zip) { _ in
+            guard let url = await ICloudBackupManager.exportArchive() else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            return SentTransferredFile(url)
         }
     }
 }

--- a/DJDX/Views/More/MoreMenu.swift
+++ b/DJDX/Views/More/MoreMenu.swift
@@ -68,7 +68,7 @@ struct MoreMenu: View {
                 }
             }
             Section("More.ManageData.Header") {
-                Button("More.ManageData.ICloudBackup", systemImage: "icloud") {
+                Button("More.ManageData.Backup", systemImage: "icloud") {
                     isPresentingICloudBackup = true
                 }
                 Menu("More.ManageData.DeleteOrReset", systemImage: "trash") {

--- a/DJDX/Views/Polaris Chord/Scores/PolarisChordScoreFilter.swift
+++ b/DJDX/Views/Polaris Chord/Scores/PolarisChordScoreFilter.swift
@@ -36,13 +36,12 @@ struct PolarisChordScoreFilterSheet: View {
                         PolarisChordFilterDisclosureLabel("Shared.Level", count: difficultiesToShow.count)
                     }
                     DisclosureGroup {
-                        ForEach(availableLevels, id: \.self) { level in
-                            PolarisChordSelectableRow(isSelected: levelsToShow.contains(level)) {
-                                Text(verbatim: level)
-                            } action: {
-                                toggle(level, in: $levelsToShow)
-                            }
-                        }
+                        FilterLevelGrid(
+                            items: availableLevels,
+                            selection: levelsToShow,
+                            title: { $0 },
+                            onToggle: { toggle($0, in: $levelsToShow) }
+                        )
                     } label: {
                         PolarisChordFilterDisclosureLabel("Shared.Sort.Difficulty", count: levelsToShow.count)
                     }

--- a/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreFilter.swift
+++ b/DJDX/Views/SOUND VOLTEX/Scores/SDVXScoreFilter.swift
@@ -37,13 +37,12 @@ struct SDVXScoreFilterSheet: View {
                         SDVXFilterDisclosureLabel("Shared.Level", count: difficultiesToShow.count)
                     }
                     DisclosureGroup {
-                        ForEach(availableLevelBuckets, id: \.self) { bucket in
-                            SDVXSelectableRow(isSelected: levelBucketsToShow.contains(bucket)) {
-                                Text(verbatim: String(format: "%.1f", bucket))
-                            } action: {
-                                toggle(bucket, in: $levelBucketsToShow)
-                            }
-                        }
+                        FilterLevelGrid(
+                            items: availableLevelBuckets,
+                            selection: levelBucketsToShow,
+                            title: { String(format: "%.1f", $0) },
+                            onToggle: { toggle($0, in: $levelBucketsToShow) }
+                        )
                     } label: {
                         SDVXFilterDisclosureLabel("Shared.Sort.Difficulty", count: levelBucketsToShow.count)
                     }

--- a/DJDX/Views/Sessions/ActiveSessionView.swift
+++ b/DJDX/Views/Sessions/ActiveSessionView.swift
@@ -8,6 +8,7 @@ struct ActiveSessionView: View {
     @State private var isPresentingCamera: Bool = false
     @State private var pickerItems: [PhotosPickerItem] = []
     @State private var isShowingCameraDeniedAlert: Bool = false
+    @State private var isShowingCameraUnavailableAlert: Bool = false
     @State private var photoAlert: PhotoExportAlert?
     @State private var isConfirmingExport: Bool = false
     @ObservedObject private var workoutBridge = IIDXSessionWorkoutBridge.shared
@@ -40,7 +41,7 @@ struct ActiveSessionView: View {
                         }
                     }
                 }
-                if workoutBridge.isWorkoutActive {
+                if workoutBridge.isSessionActive {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {
                             workoutBridge.setWorkoutPaused(!workoutBridge.isPaused)
@@ -71,6 +72,9 @@ struct ActiveSessionView: View {
                 isPresentingCamera = false
             } onCancel: {
                 isPresentingCamera = false
+            } onUnavailable: {
+                isPresentingCamera = false
+                isShowingCameraUnavailableAlert = true
             }
         }
         .onChange(of: pickerItems) { _, items in
@@ -89,6 +93,11 @@ struct ActiveSessionView: View {
             Button("Shared.OK", role: .cancel) {}
         } message: {
             Text("Sessions.Camera.Denied.Message")
+        }
+        .alert("Sessions.Camera.Unavailable.Title", isPresented: $isShowingCameraUnavailableAlert) {
+            Button("Shared.OK", role: .cancel) {}
+        } message: {
+            Text("Sessions.Camera.Unavailable.Message")
         }
         .alert("Sessions.Photos.ExportAll.Confirm", isPresented: $isConfirmingExport) {
             Button("Sessions.Photos.ExportAll") {
@@ -141,7 +150,7 @@ struct ActiveSessionView: View {
                         Text("Sessions.Elapsed")
                             .font(.body)
                             .foregroundStyle(.secondary)
-                        Text(verbatim: elapsedString(since: session.startDate, now: context.date))
+                        Text(verbatim: elapsedString(for: session, now: context.date))
                             .font(numberFont)
                     }
                     Spacer()
@@ -286,8 +295,15 @@ struct ActiveSessionView: View {
         var id: Int { rawValue }
     }
 
-    private func elapsedString(since start: Date, now: Date) -> String {
-        let interval = Int(max(0, now.timeIntervalSince(start)))
+    private func elapsedString(for session: IIDXPlaySession, now: Date) -> String {
+        let elapsed: TimeInterval
+        if workoutBridge.isPaused {
+            elapsed = workoutBridge.pausedElapsed ?? 0
+        } else {
+            let anchor = workoutBridge.runningStart ?? session.startDate
+            elapsed = now.timeIntervalSince(anchor)
+        }
+        let interval = Int(max(0, elapsed))
         let hours = interval / 3600
         let minutes = (interval % 3600) / 60
         let seconds = interval % 60

--- a/DJDX/Views/Sessions/SessionCameraView.swift
+++ b/DJDX/Views/Sessions/SessionCameraView.swift
@@ -5,11 +5,13 @@ import UIKit
 struct SessionCameraView: UIViewControllerRepresentable {
     var onCapture: (Data) -> Void
     var onCancel: () -> Void
+    var onUnavailable: () -> Void = {}
 
     func makeUIViewController(context: Context) -> SessionCameraViewController {
         let controller = SessionCameraViewController()
         controller.onCapture = onCapture
         controller.onCancel = onCancel
+        controller.onUnavailable = onUnavailable
         return controller
     }
 
@@ -19,6 +21,7 @@ struct SessionCameraView: UIViewControllerRepresentable {
 final class SessionCameraViewController: UIViewController {
     var onCapture: ((Data) -> Void)?
     var onCancel: (() -> Void)?
+    var onUnavailable: (() -> Void)?
 
     private let session = AVCaptureSession()
     private let photoOutput = AVCapturePhotoOutput()
@@ -185,6 +188,7 @@ final class SessionCameraViewController: UIViewController {
               session.canAddInput(input),
               session.canAddOutput(photoOutput) else {
             session.commitConfiguration()
+            DispatchQueue.main.async { [weak self] in self?.onUnavailable?() }
             return
         }
         session.addInput(input)
@@ -197,12 +201,14 @@ final class SessionCameraViewController: UIViewController {
             self.rotationCoordinator = AVCaptureDevice.RotationCoordinator(
                 device: device, previewLayer: self.previewLayer
             )
+            self.shutterButton.isEnabled = true
             self.view.setNeedsLayout()
         }
     }
 
     private func configureControls() {
         shutterButton.translatesAutoresizingMaskIntoConstraints = false
+        shutterButton.isEnabled = false
         if #available(iOS 26.0, *) {
             var shutterConfig = UIButton.Configuration.clearGlass()
             shutterConfig.cornerStyle = .fixed

--- a/DJDX/Views/Sessions/SessionDetailView.swift
+++ b/DJDX/Views/Sessions/SessionDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct SessionDetailView: View {
     var store: IIDXSessionStore
@@ -9,6 +10,8 @@ struct SessionDetailView: View {
     @State private var isDJLevelExpanded: Bool = true
     @State private var isClearTypeExpanded: Bool = true
     @State private var isPlaysExpanded: Bool = true
+    @State private var isConfirmingExport: Bool = false
+    @State private var photoAlert: PhotoExportAlert?
 
     var body: some View {
         ScrollView {
@@ -39,11 +42,59 @@ struct SessionDetailView: View {
         }
         .navigationTitle("Sessions.Detail.Title")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if !plays.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Sessions.Photos.ExportAll", systemImage: "square.and.arrow.up.on.square") {
+                        isConfirmingExport = true
+                    }
+                }
+            }
+        }
         .onAppear { plays = store.plays(for: session) }
         .onReceive(NotificationCenter.default.publisher(for: .capturedPlayDidChange)
             .receive(on: RunLoop.main)) { _ in
             plays = store.plays(for: session)
         }
+        .alert("Sessions.Photos.ExportAll.Confirm", isPresented: $isConfirmingExport) {
+            Button("Sessions.Photos.ExportAll") {
+                exportAllToPhotos()
+            }
+            Button("Shared.Cancel", role: .cancel) {}
+        }
+        .alert(item: $photoAlert) { alert in
+            switch alert {
+            case .saved:
+                return Alert(title: Text("Sessions.Photos.Saved"), dismissButton: .default(Text("Shared.OK")))
+            case .failed:
+                return Alert(title: Text("Sessions.Photos.Failed"), dismissButton: .default(Text("Shared.OK")))
+            case .denied:
+                return Alert(
+                    title: Text("Sessions.Photos.Denied.Title"),
+                    message: Text("Sessions.Photos.Denied.Message"),
+                    dismissButton: .default(Text("Shared.OK"))
+                )
+            }
+        }
+    }
+
+    private func exportAllToPhotos() {
+        let filenames = plays.map(\.rawImageFilename)
+        Task {
+            let images: [UIImage] = await Task.detached {
+                filenames.compactMap { IIDXSessionImageStore.shared.image(for: $0) }
+            }.value
+            switch await SessionPhotoExporter.save(images) {
+            case .saved: photoAlert = .saved
+            case .denied: photoAlert = .denied
+            case .failed: photoAlert = .failed
+            }
+        }
+    }
+
+    private enum PhotoExportAlert: Int, Identifiable {
+        case saved, denied, failed
+        var id: Int { rawValue }
     }
 
     private var summarySection: some View {

--- a/DJDX/Views/Shared/FilterLevelGrid.swift
+++ b/DJDX/Views/Shared/FilterLevelGrid.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import UIKit
+
+struct FilterLevelGrid<Element: Hashable>: View {
+
+    let items: [Element]
+    let selection: Set<Element>
+    let title: (Element) -> String
+    let onToggle: (Element) -> Void
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 0.0), count: 4)
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 0.0) {
+            ForEach(items, id: \.self) { item in
+                let isSelected = selection.contains(item)
+                Button {
+                    onToggle(item)
+                } label: {
+                    Text(verbatim: title(item))
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(isSelected ? Color.white : Color.primary)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44.0)
+                        .background(isSelected ? Color.accentColor : Color(uiColor: .secondarySystemGroupedBackground))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .listRowInsets(EdgeInsets())
+        .listRowBackground(Color.clear)
+    }
+}

--- a/DJDX/Views/UnifiedView+DeepLink.swift
+++ b/DJDX/Views/UnifiedView+DeepLink.swift
@@ -44,14 +44,16 @@ extension UnifiedView {
                 appMode = .sessions
                 if sessionStore.activeSession == nil { sessionStore.startSession() }
             case "capture":
-                navigationManager.popToRoot()
-                appMode = .sessions
-                sessionStore.requestCapture()
+                if sessionStore.activeSession != nil {
+                    navigationManager.popToRoot()
+                    appMode = .sessions
+                    sessionStore.requestCapture()
+                }
             case "stop":
                 if sessionStore.activeSession != nil { sessionStore.endSession() }
             case "pause":
                 let bridge = IIDXSessionWorkoutBridge.shared
-                if bridge.isWorkoutActive { bridge.setWorkoutPaused(!bridge.isPaused) }
+                if bridge.isSessionActive { bridge.setWorkoutPaused(!bridge.isPaused) }
             default:
                 return
             }

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -15,6 +15,7 @@ struct UnifiedView: View {
     var polarisChordVersion: PolarisChordVersion
     @AppStorage(wrappedValue: DDRVersion.world, "Global.DDR.Version") var ddrVersion: DDRVersion
     @AppStorage(wrappedValue: DDRPlayStyle.single, "Global.DDR.Style") var ddrStyleToShow: DDRPlayStyle
+    @AppStorage(wrappedValue: false, "ExternalData.DDR.Enabled") var isDDRExternalDataEnabled: Bool
     @AppStorage(wrappedValue: .single, "ScoresView.PlayTypeFilter") var playTypeToShow: IIDXPlayType
     @AppStorage(wrappedValue: true, "More.General.ShowProfileHeader") var showProfileHeader: Bool
     @AppStorage(wrappedValue: true, "More.General.ShowAnalytics") var showAnalytics: Bool

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -231,8 +231,10 @@ struct UnifiedView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .endSessionRequested)
-            .receive(on: RunLoop.main)) { _ in
-            if sessionStore.activeSession != nil {
+            .receive(on: RunLoop.main)) { notification in
+            let requestedID = notification.object as? String
+            if let active = sessionStore.activeSession,
+               requestedID == nil || requestedID == active.id {
                 sessionStore.endSession()
             }
         }

--- a/DJDX/Views/beatmania IIDX/Scores/IIDXScoreSortMenu.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/IIDXScoreSortMenu.swift
@@ -100,19 +100,18 @@ struct ScoreFilterSheet: View {
                                               countLabel: LocalizedStringResource("Shared.Filter.Count.Levels"))
                     }
                     DisclosureGroup {
-                        ForEach(IIDXDifficulty.sorted, id: \.self) { difficulty in
-                            SelectableRow(
-                                isSelected: difficultiesToShow.contains(difficulty)
-                            ) {
-                                Text("LEVEL \(difficulty.rawValue)")
-                            } action: {
+                        FilterLevelGrid(
+                            items: IIDXDifficulty.sorted,
+                            selection: difficultiesToShow,
+                            title: { String($0.rawValue) },
+                            onToggle: { difficulty in
                                 if difficultiesToShow.contains(difficulty) {
                                     difficultiesToShow.remove(difficulty)
                                 } else {
                                     difficultiesToShow.insert(difficulty)
                                 }
                             }
-                        }
+                        )
                     } label: {
                         FilterDisclosureLabel(.sharedDifficulty, count: difficultiesToShow.count,
                                               countLabel: LocalizedStringResource("Shared.Filter.Count.Difficulties"))

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1318,6 +1318,57 @@
         }
       }
     },
+    "Backup.Export" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Data…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データを書き出す…"
+          }
+        }
+      }
+    },
+    "Backup.Export.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save or share a ZIP file containing all of your data."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのデータを含むZIPファイルを保存・共有できます。"
+          }
+        }
+      }
+    },
+    "Backup.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックアップ"
+          }
+        }
+      }
+    },
     "Calendar.BackToToday" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1665,23 +1716,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バックアップを復元中"
-          }
-        }
-      }
-    },
-    "ICloudBackup.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iCloud Backup"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iCloudバックアップ"
           }
         }
       }
@@ -2519,6 +2553,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アナリティクスキャッシュをクリア"
+          }
+        }
+      }
+    },
+    "More.ManageData.Backup" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックアップ"
           }
         }
       }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -3233,6 +3233,40 @@
         }
       }
     },
+    "Sessions.Camera.Unavailable.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The camera could not be started. Close other apps that may be using the camera, then try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カメラを起動できませんでした。カメラを使用している他のアプリを終了してから、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "Sessions.Camera.Unavailable.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera Unavailable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カメラを使用できません"
+          }
+        }
+      }
+    },
     "Sessions.Capture" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -1444,6 +1444,57 @@
     "Date" : {
       "shouldTranslate" : false
     },
+    "DDR.DataSource.Warning.Action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Data Sources"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部データソースを開く"
+          }
+        }
+      }
+    },
+    "DDR.DataSource.Warning.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When BEMANIWiki data is turned off, chart levels are not downloaded and won't appear."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BEMANIWikiデータをオフにしていると、譜面のレベルが取得されず、表示されません。"
+          }
+        }
+      }
+    },
+    "DDR.DataSource.Warning.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Levels May Not Appear"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レベルが表示されない場合があります"
+          }
+        }
+      }
+    },
     "Default" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
Addresses the holes and logic issues found in a review of the Sessions feature and the Apple Watch app/complication (the #107 work), plus one extra bug: export-all was only available in the active session, not the post-session detail view.

It also folds in issues #109 (Improve DDR support) and #110 (filter level grid) rather than opening separate PRs.

Closes #109
Closes #110

## iPhone ↔ Watch workout sync
- **Reliable WCSession delivery** — `sendMessage` now falls back to queued `transferUserInfo` on failure, so `start`/`end`/`setPaused`/`workoutUUID` are no longer silently dropped on a flaky link.
- **Watch-initiated start no longer orphans a workout** — when the watch starts a session while the phone already has one, the phone reconciles and sends `adoptSession`; the watch re-IDs its running `HKWorkoutSession` onto the phone's session instead of streaming to an unknown one.
- **Watch HealthKit auth/start failure recovers** — tears down the half-started workout and notifies the phone instead of leaving a perpetual fake "running" workout with no data and no pause button.
- **sessionID validation** on `applyWorkoutState` and the `endSession` observer, so stale/queued messages can't clobber a newer session.
- **Fallback workout gating** — a saved workout now depends on whether the watch actually ran one, not on pairing; fixes the paired-but-app-not-installed silent loss.

## State & lifecycle
- Bridge **reconciles against the active session on launch/foreground** and re-pulls pause state, so pause/heart-rate/timer work after relaunch.
- **Phone-owned pause** — optimistic local + Live Activity update, pause-aware in-app timer; pause now works even without a watch and stays consistent across iPhone/Watch/Live Activity.
- **SQLite `busyTimeout`** so the OCR actor and main actor don't drop writes/reads under contention; `endSession` reports success to avoid resurrecting a "zombie" session.
- Live Activity `Activity.request` failure no longer leaves a dangling `sessionID`.

## OCR / parsing quality
- DJ level only derived from a **plausible notes count** (≥ read judgments), else falls back to the rank classifier; a hard disagreement is flagged for review.
- Reconciled judge counts are **bounded by the note total**, and the fabricated-relation confidence bonus is removed.
- Plays are marked **needsReview when per-region OCR actually errored** (vs. a silent zero).

## Watch UI / camera
- Watch profile fields **clear** when cleared on the phone (full-context sync with empty markers).
- Camera surfaces an **alert on capture-session failure**; shutter stays disabled until the session is running.
- Capture deep link guarded on an active session.
- Watch radar colour bands matched to the complication.

## Extra bug
- **Export-all-to-Photos added to the post-session detail view** (previously only in the active session).

---

# Improve DDR support (#109)

- **Fix clear-lamp sort** — the scraped Life4 stem is `li4clear`, but `clearLampOrder`/`clearColor` used `life4`, so Life4 clears fell to the unknown sort index (sorting below `CLEAR`) and were mis-bucketed as NO CLEAR in analytics. Uses the real stem.
- **Leading bar = clear colour** — the score row's leading edge bar now reflects the clear lamp instead of the difficulty (difficulty is still shown by the level badge).
- **Hide unknown levels** — when a chart's level isn't populated, the number is hidden instead of showing `?`.
- **BEMANIWiki data warning** — a Sessions-style banner above the DDR profile header when DDR external data is off (levels can't be populated without it); tapping it opens External Data Sources.
- **Rank breakdown by level** — the DDR rank breakdown detail now groups by chart level instead of difficulty, mirroring the clear-type breakdown.
- **Manual data export** — "iCloud Backup" becomes a generic "Backup" view: iCloud section on top, plus an "Export Data…" `ShareLink` that zips the app container and shares it (works without iCloud; uses a `Transferable` so the share sheet anchors correctly on iPad).

# Filter level grid (#110)

- Replaces the long vertical level list in **every game's** filter sheet with a dial-pad-style 4-column grid (`FilterLevelGrid`): numbers in body-semibold, unselected cells use the default grouped row background with primary text, selected cells use the accent colour with white text, no cell padding, transparent unfilled cells, no checkmark.

## Verification
- `xcodebuild` of the full project (iOS app + Watch app + iOS widgets + Watch complication) succeeds after every commit.
- Not yet exercised on a simulator/device; the Sessions sync behaviour is reasoned-through, and the DDR/filter UI changes are build-verified but not visually confirmed on a running app.
