### PR TITLE
Support Textage Chart Viewer

### DIFF
--- a/DJDX.xcodeproj/project.pbxproj
+++ b/DJDX.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -542,7 +542,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -609,7 +609,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -783,7 +783,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -828,7 +828,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.DJDX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -859,7 +859,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.DJDX.watchkitapp.DJDX-CHARGE-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -892,7 +892,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 33.4;
+				MARKETING_VERSION = 33.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.DJDX.watchkitapp.DJDX-CHARGE-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/DJDX/Classes/ExternalDataReloader.swift
+++ b/DJDX/Classes/ExternalDataReloader.swift
@@ -3,6 +3,7 @@ import SwiftSoup
 
 enum ExternalDataSourceID: String, CaseIterable {
     case textage
+    case textageChartViewer
     case sdvxIn
     case wikiIidx
     case bm2dx
@@ -22,6 +23,7 @@ struct ExternalDataReloader {
     ) async -> Int {
         switch id {
         case .textage: await reloadTextage(progress: progress)
+        case .textageChartViewer: await reloadTextageChartViewer(progress: progress)
         case .sdvxIn: await reloadSDVXIn(progress: progress)
         case .wikiIidx: await reloadWikiIIDX(version: iidxVersion, progress: progress)
         case .bm2dx: await reloadBM2DX(progress: progress)
@@ -54,6 +56,47 @@ struct ExternalDataReloader {
                                                accessTableText: accessTableText)
         await TextageImporter().replaceAllCharts(charts)
         return await IIDXReader().textageChartCount()
+    }
+
+    // MARK: - Textage Chart Viewer
+
+    private static func reloadTextageChartViewer(progress: Progress) async -> Int {
+        progress(0, 1)
+        guard let url = URL(string: "https://textage-chart-viewer.vercel.app/api/songs"),
+              let (data, _) = try? await URLSession.shared.data(from: url),
+              let response = try? JSONDecoder().decode(TextageChartViewerSongsResponse.self, from: data) else {
+            return 0
+        }
+
+        var charts: [TextageChartViewerChart] = []
+        for song in response.data {
+            let chart = TextageChartViewerChart(
+                songId: song.songId,
+                version: song.version,
+                title: song.title + (song.subtitle ?? ""),
+                spBeginner: song.levels.spBeginner,
+                spNormal: song.levels.spNormal,
+                spHyper: song.levels.spHyper,
+                spAnother: song.levels.spAnother,
+                spLeggendaria: song.levels.spLeggendaria,
+                dpBeginner: song.levels.dpBeginner,
+                dpNormal: song.levels.dpNormal,
+                dpHyper: song.levels.dpHyper,
+                dpAnother: song.levels.dpAnother,
+                dpLeggendaria: song.levels.dpLeggendaria
+            )
+            let hasAnyChart = [
+                chart.spBeginner, chart.spNormal, chart.spHyper, chart.spAnother, chart.spLeggendaria,
+                chart.dpBeginner, chart.dpNormal, chart.dpHyper, chart.dpAnother, chart.dpLeggendaria
+            ].contains { $0 > 0 }
+            if hasAnyChart, !chart.title.isEmpty {
+                charts.append(chart)
+            }
+        }
+
+        await TextageChartViewerImporter().replaceAllCharts(charts)
+        progress(1, 1)
+        return await IIDXReader().textageChartViewerChartCount()
     }
 
     // MARK: - sdvx.in
@@ -261,6 +304,32 @@ struct ExternalDataReloader {
         progress(1, 1)
         return count
     }
+}
+
+private struct TextageChartViewerSongsResponse: Decodable {
+
+    struct Song: Decodable {
+        var songId: String
+        var version: Int
+        var title: String
+        var subtitle: String?
+        var levels: Levels
+    }
+
+    struct Levels: Decodable {
+        var spBeginner: Int
+        var spNormal: Int
+        var spHyper: Int
+        var spAnother: Int
+        var spLeggendaria: Int
+        var dpBeginner: Int
+        var dpNormal: Int
+        var dpHyper: Int
+        var dpAnother: Int
+        var dpLeggendaria: Int
+    }
+
+    var data: [Song]
 }
 
 @MainActor

--- a/DJDX/Classes/TextageChartViewerDatabase.swift
+++ b/DJDX/Classes/TextageChartViewerDatabase.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SQLite
+
+final class TextageChartViewerDatabase: Sendable {
+
+    static let shared = TextageChartViewerDatabase()
+
+    let databasePath: String
+
+    // MARK: - TextageChartViewerChart Table
+
+    static let chartTable = Table("TextageChartViewerChart")
+    static let chartID = SQLite.Expression<Int64>("id")
+    static let chartSongId = SQLite.Expression<String>("songId")
+    static let chartVersion = SQLite.Expression<Int>("version")
+    static let chartTitle = SQLite.Expression<String>("title")
+    static let chartTitleCompact = SQLite.Expression<String>("titleCompact")
+    static let chartSPBeginner = SQLite.Expression<Int>("spBeginner")
+    static let chartSPNormal = SQLite.Expression<Int>("spNormal")
+    static let chartSPHyper = SQLite.Expression<Int>("spHyper")
+    static let chartSPAnother = SQLite.Expression<Int>("spAnother")
+    static let chartSPLeggendaria = SQLite.Expression<Int>("spLeggendaria")
+    static let chartDPBeginner = SQLite.Expression<Int>("dpBeginner")
+    static let chartDPNormal = SQLite.Expression<Int>("dpNormal")
+    static let chartDPHyper = SQLite.Expression<Int>("dpHyper")
+    static let chartDPAnother = SQLite.Expression<Int>("dpAnother")
+    static let chartDPLeggendaria = SQLite.Expression<Int>("dpLeggendaria")
+
+    // MARK: - Initialization
+
+    private init() {
+        databasePath = SharedContainer.containerURL.appendingPathComponent("ExD_TextageChartViewer.db").path
+        createTablesIfNeeded()
+    }
+
+    // MARK: - Connection
+
+    func getReadConnection() throws -> Connection {
+        let connection = try Connection(databasePath, readonly: true)
+        return connection
+    }
+
+    func getWriteConnection() throws -> Connection {
+        let connection = try Connection(databasePath)
+        return connection
+    }
+
+    // MARK: - Table Creation
+
+    private func createTablesIfNeeded() {
+        do {
+            let database = try Connection(databasePath)
+
+            try database.run(Self.chartTable.create(ifNotExists: true) { table in
+                table.column(Self.chartID, primaryKey: .autoincrement)
+                table.column(Self.chartSongId, defaultValue: "")
+                table.column(Self.chartVersion, defaultValue: 0)
+                table.column(Self.chartTitle, defaultValue: "")
+                table.column(Self.chartTitleCompact, defaultValue: "")
+                table.column(Self.chartSPBeginner, defaultValue: 0)
+                table.column(Self.chartSPNormal, defaultValue: 0)
+                table.column(Self.chartSPHyper, defaultValue: 0)
+                table.column(Self.chartSPAnother, defaultValue: 0)
+                table.column(Self.chartSPLeggendaria, defaultValue: 0)
+                table.column(Self.chartDPBeginner, defaultValue: 0)
+                table.column(Self.chartDPNormal, defaultValue: 0)
+                table.column(Self.chartDPHyper, defaultValue: 0)
+                table.column(Self.chartDPAnother, defaultValue: 0)
+                table.column(Self.chartDPLeggendaria, defaultValue: 0)
+            })
+
+            try database.run(Self.chartTable.createIndex(
+                Self.chartTitleCompact,
+                unique: true,
+                ifNotExists: true
+            ))
+        } catch {
+            debugPrint("Failed to create Textage Chart Viewer tables: \(error)")
+        }
+    }
+}

--- a/DJDX/Enums/ViewPath.swift
+++ b/DJDX/Enums/ViewPath.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum ScoresPath: Hashable {
     case scoreViewer(songRecord: IIDXSongRecord, initialLevel: IIDXLevel = .all)
-    case textageViewer(url: URL)
+    case textageViewer(legacyURL: URL?, chartViewerURL: URL?)
 }
 
 enum AnalyticsPath: Hashable {

--- a/DJDX/Games/beatmania IIDX/Data Types/TextageChartViewerChart.swift
+++ b/DJDX/Games/beatmania IIDX/Data Types/TextageChartViewerChart.swift
@@ -45,7 +45,8 @@ struct TextageChartViewerChart: Sendable, Hashable {
         case .single: playTypeCode = "sp"
         case .double: playTypeCode = "dp"
         }
-        let path = "chart/\(version)/\(songId)/\(difficultyCode)/\(playTypeCode)"
+        let folder = version == 35 ? "s" : String(version)
+        let path = "chart/\(folder)/\(songId)/\(difficultyCode)/\(playTypeCode)"
         return URL(string: "https://textage-chart-viewer.vercel.app/\(path)")
     }
 

--- a/DJDX/Games/beatmania IIDX/Data Types/TextageChartViewerChart.swift
+++ b/DJDX/Games/beatmania IIDX/Data Types/TextageChartViewerChart.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct TextageChartViewerChart: Sendable, Hashable {
+
+    var songId: String
+    var version: Int
+    var title: String
+
+    var spBeginner: Int
+    var spNormal: Int
+    var spHyper: Int
+    var spAnother: Int
+    var spLeggendaria: Int
+    var dpBeginner: Int
+    var dpNormal: Int
+    var dpHyper: Int
+    var dpAnother: Int
+    var dpLeggendaria: Int
+
+    func level(for difficulty: IIDXLevel, playType: IIDXPlayType) -> Int {
+        switch (playType, difficulty) {
+        case (.single, .beginner): return spBeginner
+        case (.single, .normal): return spNormal
+        case (.single, .hyper): return spHyper
+        case (.single, .another): return spAnother
+        case (.single, .leggendaria): return spLeggendaria
+        case (.double, .beginner): return dpBeginner
+        case (.double, .normal): return dpNormal
+        case (.double, .hyper): return dpHyper
+        case (.double, .another): return dpAnother
+        case (.double, .leggendaria): return dpLeggendaria
+        default: return 0
+        }
+    }
+
+    func hasChart(for difficulty: IIDXLevel, playType: IIDXPlayType) -> Bool {
+        level(for: difficulty, playType: playType) > 0
+    }
+
+    func pageURL(for difficulty: IIDXLevel, playType: IIDXPlayType) -> URL? {
+        guard hasChart(for: difficulty, playType: playType),
+              let difficultyCode = Self.difficultyCode(for: difficulty) else { return nil }
+        let playTypeCode: String
+        switch playType {
+        case .single: playTypeCode = "sp"
+        case .double: playTypeCode = "dp"
+        }
+        let path = "chart/\(version)/\(songId)/\(difficultyCode)/\(playTypeCode)"
+        return URL(string: "https://textage-chart-viewer.vercel.app/\(path)")
+    }
+
+    private static func difficultyCode(for difficulty: IIDXLevel) -> String? {
+        switch difficulty {
+        case .beginner: return "b"
+        case .normal: return "n"
+        case .hyper: return "h"
+        case .another: return "a"
+        case .leggendaria: return "l"
+        default: return nil
+        }
+    }
+}

--- a/DJDX/Games/beatmania IIDX/IIDXReader.swift
+++ b/DJDX/Games/beatmania IIDX/IIDXReader.swift
@@ -498,6 +498,33 @@ actor IIDXReader {
         )
     }
 
+    func textageChartViewerChartCount() -> Int {
+        guard let database = try? TextageChartViewerDatabase.shared.getReadConnection() else { return 0 }
+        return (try? database.scalar(TextageChartViewerDatabase.chartTable.count)) ?? 0
+    }
+
+    func textageChartViewerChart(title: String) -> TextageChartViewerChart? {
+        guard let database = try? TextageChartViewerDatabase.shared.getReadConnection() else { return nil }
+        let col = TextageChartViewerDatabase.self
+        let query = col.chartTable.filter(col.chartTitleCompact == title.compact).limit(1)
+        guard let row = try? database.pluck(query) else { return nil }
+        return TextageChartViewerChart(
+            songId: row[col.chartSongId],
+            version: row[col.chartVersion],
+            title: row[col.chartTitle],
+            spBeginner: row[col.chartSPBeginner],
+            spNormal: row[col.chartSPNormal],
+            spHyper: row[col.chartSPHyper],
+            spAnother: row[col.chartSPAnother],
+            spLeggendaria: row[col.chartSPLeggendaria],
+            dpBeginner: row[col.chartDPBeginner],
+            dpNormal: row[col.chartDPNormal],
+            dpHyper: row[col.chartDPHyper],
+            dpAnother: row[col.chartDPAnother],
+            dpLeggendaria: row[col.chartDPLeggendaria]
+        )
+    }
+
     // MARK: Analytics - Aggregated Counts
 
     private struct LevelColumns {

--- a/DJDX/Games/beatmania IIDX/TextageChartViewerImporter.swift
+++ b/DJDX/Games/beatmania IIDX/TextageChartViewerImporter.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SQLite
+
+actor TextageChartViewerImporter {
+
+    // swiftlint:disable:next type_name
+    typealias DB = TextageChartViewerDatabase
+
+    func replaceAllCharts(_ charts: [TextageChartViewerChart]) {
+        guard let database = try? DB.shared.getWriteConnection() else { return }
+        try? database.transaction {
+            _ = try? database.run(DB.chartTable.delete())
+            for chart in charts {
+                _ = try? database.run(DB.chartTable.insert(
+                    or: .replace,
+                    DB.chartSongId <- chart.songId,
+                    DB.chartVersion <- chart.version,
+                    DB.chartTitle <- chart.title,
+                    DB.chartTitleCompact <- chart.title.compact,
+                    DB.chartSPBeginner <- chart.spBeginner,
+                    DB.chartSPNormal <- chart.spNormal,
+                    DB.chartSPHyper <- chart.spHyper,
+                    DB.chartSPAnother <- chart.spAnother,
+                    DB.chartSPLeggendaria <- chart.spLeggendaria,
+                    DB.chartDPBeginner <- chart.dpBeginner,
+                    DB.chartDPNormal <- chart.dpNormal,
+                    DB.chartDPHyper <- chart.dpHyper,
+                    DB.chartDPAnother <- chart.dpAnother,
+                    DB.chartDPLeggendaria <- chart.dpLeggendaria
+                ))
+            }
+        }
+    }
+
+    func deleteAllCharts() {
+        guard let database = try? DB.shared.getWriteConnection() else { return }
+        _ = try? database.run(DB.chartTable.delete())
+    }
+}

--- a/DJDX/Views/More/MoreExternalDataSources.swift
+++ b/DJDX/Views/More/MoreExternalDataSources.swift
@@ -8,6 +8,7 @@ struct MoreExternalDataSources: View {
     @Environment(\.dismiss) var dismiss
 
     @AppStorage(wrappedValue: false, "ExternalData.Textage.Enabled") var isTextageEnabled: Bool
+    @AppStorage(wrappedValue: false, "ExternalData.TextageChartViewer.Enabled") var isTextageChartViewerEnabled: Bool
     @AppStorage(wrappedValue: false, "ExternalData.SDVXIn.Enabled") var isSDVXInEnabled: Bool
     @AppStorage(wrappedValue: false, "ExternalData.BemaniWiki2nd.Enabled") var isBemaniWikiEnabled: Bool
     @AppStorage(wrappedValue: false, "ExternalData.BM2DX.Enabled") var isBM2DXEnabled: Bool
@@ -18,19 +19,21 @@ struct MoreExternalDataSources: View {
     @State var bm2dxEntryCount: Int = 0
     @State var sdvxInEntryCount: Int = 0
     @State var textageEntryCount: Int = 0
+    @State var textageChartViewerEntryCount: Int = 0
     @State var ddrSongMetaCount: Int = 0
 
     @State var isBemaniWikiReloadCompleted: Bool = false
     @State var isBM2DXReloadCompleted: Bool = false
     @State var isSDVXInReloadCompleted: Bool = false
     @State var isTextageReloadCompleted: Bool = false
+    @State var isTextageChartViewerReloadCompleted: Bool = false
     @State var isDDRReloadCompleted: Bool = false
     @State var dataImported: Int = 0
     @State var dataTotal: Int = 2
     @State var reloadingSource: ExternalDataReloadSource?
 
     enum ExternalDataReloadSource {
-        case bemaniWiki, bm2dx, sdvxIn, textage, ddr
+        case bemaniWiki, bm2dx, sdvxIn, textage, textageChartViewer, ddr
     }
 
     let fetcher = IIDXReader()
@@ -39,6 +42,7 @@ struct MoreExternalDataSources: View {
 
     var body: some View {
         List {
+            textageChartViewerSection()
             textageSection()
             sdvxInSection()
             bemaniWikiSection()
@@ -46,7 +50,8 @@ struct MoreExternalDataSources: View {
         }
         .navigationTitle("More.ExternalData.Header")
         .navigationBarTitleDisplayMode(.inline)
-        .onChange(of: [isTextageEnabled, isSDVXInEnabled, isBemaniWikiEnabled, isBM2DXEnabled, isDDREnabled]) { _, _ in
+        .onChange(of: [isTextageEnabled, isTextageChartViewerEnabled, isSDVXInEnabled,
+                       isBemaniWikiEnabled, isBM2DXEnabled, isDDREnabled]) { _, _ in
             NotificationCenter.default.post(name: .externalDataChanged, object: nil)
         }
         .toolbar {
@@ -72,6 +77,7 @@ struct MoreExternalDataSources: View {
             bm2dxEntryCount = await fetcher.chartRadarDataCount()
             sdvxInEntryCount = await sdvxFetcher.sdvxInChartCount()
             textageEntryCount = await fetcher.textageChartCount()
+            textageChartViewerEntryCount = await fetcher.textageChartViewerChartCount()
             ddrSongMetaCount = await ddrMetaImporter.songMetaCount()
         }
         .alert(
@@ -120,6 +126,18 @@ struct MoreExternalDataSources: View {
             },
             message: {
                 Text("Alert.ExternalData.Completed.Text.\(textageEntryCount)")
+            }
+        )
+        .alert(
+            "Alert.ExternalData.Completed.Title",
+            isPresented: $isTextageChartViewerReloadCompleted,
+            actions: {
+                Button("Shared.OK", role: .cancel) {
+                    isTextageChartViewerReloadCompleted = false
+                }
+            },
+            message: {
+                Text("Alert.ExternalData.Completed.Text.\(textageChartViewerEntryCount)")
             }
         )
         .alert(
@@ -193,7 +211,7 @@ struct MoreExternalDataSources: View {
     private func reloadIndicator(for source: ExternalDataReloadSource) -> some View {
         if reloadingSource == source {
             switch source {
-            case .bm2dx, .ddr:
+            case .bm2dx, .ddr, .textageChartViewer:
                 ProgressView()
             default:
                 ProgressDonut(progress: dataTotal > 0 ? Double(dataImported) / Double(dataTotal) : 0.0)
@@ -302,10 +320,45 @@ struct MoreExternalDataSources: View {
         }
     }
 
+    // MARK: - Textage Chart Viewer
+
+    @ViewBuilder
+    private func textageChartViewerSection() -> some View {
+        Section {
+            dataSourceCard(
+                title: { Text("More.ExternalData.TextageChartViewer.Description") },
+                count: textageChartViewerEntryCount,
+                isOn: $isTextageChartViewerEnabled,
+                source: .textageChartViewer,
+                reload: reloadTextageChartViewerData,
+                completed: $isTextageChartViewerReloadCompleted
+            )
+        } header: {
+            ListSectionHeader(text: "More.ExternalData.TextageChartViewer")
+                .font(.body)
+        } footer: {
+            Text("More.ExternalData.TextageChartViewer.Footer") +
+            Text(" ") +
+            Text("[\(String(localized: "More.ExternalData.ViewSource"))](https://textage-chart-viewer.vercel.app)")
+        }
+    }
+
     // MARK: - Textage Data Loading
 
     func reloadTextageData() async {
         textageEntryCount = await ExternalDataReloader.reload(.textage, iidxVersion: iidxVersion) { done, total in
+            dataImported = done
+            dataTotal = total
+        }
+    }
+
+    // MARK: - Textage Chart Viewer Data Loading
+
+    func reloadTextageChartViewerData() async {
+        textageChartViewerEntryCount = await ExternalDataReloader.reload(
+            .textageChartViewer,
+            iidxVersion: iidxVersion
+        ) { done, total in
             dataImported = done
             dataTotal = total
         }

--- a/DJDX/Views/Shared/TextageViewer.swift
+++ b/DJDX/Views/Shared/TextageViewer.swift
@@ -121,10 +121,13 @@ struct WebViewForTextage: UIViewRepresentable {
 
     var url: URL
 
-    private static let hideWelcomeDialogScript = WKUserScript(
+    private static let chartViewerScript = WKUserScript(
         source: """
         if (location.hostname === "textage-chart-viewer.vercel.app") {
             try { localStorage.setItem("hideWelcomeDialog", "true"); } catch (error) {}
+            const style = document.createElement("style");
+            style.textContent = "header { display: none !important; }";
+            document.documentElement.appendChild(style);
         }
         """,
         injectionTime: .atDocumentStart,
@@ -132,7 +135,7 @@ struct WebViewForTextage: UIViewRepresentable {
     )
 
     func makeUIView(context: Context) -> WKWebView {
-        webView.configuration.userContentController.addUserScript(Self.hideWelcomeDialogScript)
+        webView.configuration.userContentController.addUserScript(Self.chartViewerScript)
         webView.navigationDelegate = context.coordinator
         webView.layer.opacity = 0.0
         #if DEBUG

--- a/DJDX/Views/Shared/TextageViewer.swift
+++ b/DJDX/Views/Shared/TextageViewer.swift
@@ -121,7 +121,18 @@ struct WebViewForTextage: UIViewRepresentable {
 
     var url: URL
 
+    private static let hideWelcomeDialogScript = WKUserScript(
+        source: """
+        if (location.hostname === "textage-chart-viewer.vercel.app") {
+            try { localStorage.setItem("hideWelcomeDialog", "true"); } catch (error) {}
+        }
+        """,
+        injectionTime: .atDocumentStart,
+        forMainFrameOnly: true
+    )
+
     func makeUIView(context: Context) -> WKWebView {
+        webView.configuration.userContentController.addUserScript(Self.hideWelcomeDialogScript)
         webView.navigationDelegate = context.coordinator
         webView.layer.opacity = 0.0
         #if DEBUG

--- a/DJDX/Views/Shared/TextageViewer.swift
+++ b/DJDX/Views/Shared/TextageViewer.swift
@@ -137,6 +137,7 @@ struct WebViewForTextage: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         webView.configuration.userContentController.addUserScript(Self.chartViewerScript)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.layer.opacity = 0.0
         #if DEBUG
         webView.isInspectable = true
@@ -161,13 +162,23 @@ struct WebViewForTextage: UIViewRepresentable {
         }
     }
 
-    class Coordinator: NSObject, WKNavigationDelegate {
+    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
 
         var updateState: (Bool) -> Void
 
         init(updateState: @escaping (Bool) -> Void) {
             self.updateState = updateState
             super.init()
+        }
+
+        func webView(_ webView: WKWebView,
+                     createWebViewWith configuration: WKWebViewConfiguration,
+                     for navigationAction: WKNavigationAction,
+                     windowFeatures: WKWindowFeatures) -> WKWebView? {
+            if let url = navigationAction.request.url {
+                UIApplication.shared.open(url)
+            }
+            return nil
         }
 
         func webView(_: WKWebView, didFinish _: WKNavigation!) {

--- a/DJDX/Views/Shared/TextageViewer.swift
+++ b/DJDX/Views/Shared/TextageViewer.swift
@@ -3,13 +3,35 @@ import WebKit
 
 struct TextageViewer: View {
 
+    enum Source {
+        case legacy
+        case chartViewer
+    }
+
     @Environment(\.colorScheme) var colorScheme: ColorScheme
 
-    var url: URL
+    var legacyURL: URL?
+    var chartViewerURL: URL?
 
+    @State var selectedSource: Source
     @State var webView = WKWebView()
     @State var isLoading: Bool = true
     @State var isShowingFallbackButton: Bool = false
+
+    init(legacyURL: URL?, chartViewerURL: URL?) {
+        self.legacyURL = legacyURL
+        self.chartViewerURL = chartViewerURL
+        self._selectedSource = State(initialValue: chartViewerURL != nil ? .chartViewer : .legacy)
+    }
+
+    var url: URL {
+        switch selectedSource {
+        case .legacy: legacyURL ?? chartViewerURL ?? Self.fallbackURL
+        case .chartViewer: chartViewerURL ?? legacyURL ?? Self.fallbackURL
+        }
+    }
+
+    private static let fallbackURL = URL(string: "https://textage.cc/")!
 
     var body: some View {
         WebViewForTextage(
@@ -21,6 +43,19 @@ struct TextageViewer: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
+                if legacyURL != nil && chartViewerURL != nil {
+                    ToolbarItem(placement: .principal) {
+                        Picker(selection: $selectedSource) {
+                            Text("TextageViewer.Source.ChartViewer")
+                                .tag(Source.chartViewer)
+                            Text("TextageViewer.Source.Legacy")
+                                .tag(Source.legacy)
+                        } label: {
+                            Text("ViewTitle.TextageViewer")
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Shared.Refresh", systemImage: "arrow.clockwise") {
                         refresh()
@@ -46,6 +81,9 @@ struct TextageViewer: View {
                         .clipShape(.rect(cornerRadius: 10.0))
                     }
                 }
+            }
+            .onChange(of: selectedSource) { _, _ in
+                refresh()
             }
             .task {
                 await showFallbackAfterDelay()
@@ -112,25 +150,18 @@ struct WebViewForTextage: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate {
 
         var updateState: (Bool) -> Void
-        var hasRevealed: Bool = false
 
         init(updateState: @escaping (Bool) -> Void) {
             self.updateState = updateState
             super.init()
         }
 
-        func reveal() {
-            guard !hasRevealed else { return }
-            hasRevealed = true
+        func webView(_: WKWebView, didFinish _: WKNavigation!) {
             updateState(true)
         }
 
-        func webView(_: WKWebView, didFinish _: WKNavigation!) {
-            reveal()
-        }
-
         func webView(_: WKWebView, didCommit _: WKNavigation!) {
-            reveal()
+            updateState(true)
         }
     }
 }

--- a/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/IIDXScoresView.swift
@@ -339,8 +339,8 @@ struct IIDXScoresView<Header: View>: View {
                     )
                     .automaticNavigationTransition(id: "\(songRecord.title).\(initialLevel.rawValue)",
                                                    in: scoresNamespace)
-                case .textageViewer(let url):
-                    TextageViewer(url: url)
+                case .textageViewer(let legacyURL, let chartViewerURL):
+                    TextageViewer(legacyURL: legacyURL, chartViewerURL: chartViewerURL)
                 }
             }
     }

--- a/DJDX/Views/beatmania IIDX/Scores/Viewer/IIDXScoreSection.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/Viewer/IIDXScoreSection.swift
@@ -23,6 +23,7 @@ struct IIDXScoreSection: View {
     @State private var latestDate: Date = Calendar.current.date(byAdding: .day, value: 1, to: .now)!
 
     @State private var textageChart: TextageChart?
+    @State private var textageChartViewerChart: TextageChartViewerChart?
 
     private let fetcher = IIDXReader()
 
@@ -120,6 +121,7 @@ struct IIDXScoreSection: View {
             }
             if score.level != .beginner {
                 textageChart = await fetcher.textageChart(title: songTitle)
+                textageChartViewerChart = await fetcher.textageChartViewerChart(title: songTitle)
             }
         }
     }
@@ -222,17 +224,17 @@ struct IIDXScoreSection: View {
                 chartActionLabel(image: Image(.listIconYouTube), label: "YouTube")
             }
             .buttonStyle(.plain)
-            if let textageChart, score.level != .beginner {
+            if score.level != .beginner, textageChart != nil || textageChartViewerChart != nil {
                 switch playType {
                 case .single:
-                    textageButton(chart: textageChart, playSide: .side1P,
+                    textageButton(playSide: .side1P,
                                   image: Image(.listIconTextage),
                                   label: "Scores.Viewer.OpenTextage.1P")
-                    textageButton(chart: textageChart, playSide: .side2P,
+                    textageButton(playSide: .side2P,
                                   image: Image(.listIconTextageFlipped),
                                   label: "Scores.Viewer.OpenTextage.2P")
                 case .double:
-                    textageButton(chart: textageChart, playSide: .notApplicable,
+                    textageButton(playSide: .notApplicable,
                                   image: Image(.listIconTextage),
                                   label: "Scores.Viewer.OpenTextage.DP")
                 }
@@ -241,14 +243,16 @@ struct IIDXScoreSection: View {
     }
 
     @ViewBuilder
-    func textageButton(chart: TextageChart,
-                       playSide: IIDXPlaySide,
+    func textageButton(playSide: IIDXPlaySide,
                        image: Image,
                        label: LocalizedStringKey) -> some View {
-        if let url = chart.pageURL(for: score.level, playType: playType, playSide: playSide) {
+        let legacyURL = textageChart?.pageURL(for: score.level, playType: playType, playSide: playSide)
+        let chartViewerURL = textageChartViewerChart?.pageURL(for: score.level, playType: playType)
+        if legacyURL != nil || chartViewerURL != nil {
             Divider()
             Button {
-                navigationManager.push(ScoresPath.textageViewer(url: url))
+                navigationManager.push(ScoresPath.textageViewer(legacyURL: legacyURL,
+                                                                chartViewerURL: chartViewerURL))
             } label: {
                 chartActionLabel(image: image, label: label)
             }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -3329,6 +3329,75 @@
         }
       }
     },
+    "More.ExternalData.TextageChartViewer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Textage Chart Viewer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Textage Chart Viewer"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Textage Chart Viewer"
+          }
+        }
+      }
+    },
+    "More.ExternalData.TextageChartViewer.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chart Index"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "譜面インデックス"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "譜面索引"
+          }
+        }
+      }
+    },
+    "More.ExternalData.TextageChartViewer.Footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DJDX is not affiliated with or endorsed by Textage Chart Viewer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DJDXはTextage Chart Viewerとは一切関係ありません。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DJDX 與 Textage Chart Viewer 並無任何關聯。"
+          }
+        }
+      }
+    },
     "More.ExternalData.UpdateData" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7911,6 +7980,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "譜面無法開啟嗎？\n麻煩你前往 Textage 手動搜尋看看。"
+          }
+        }
+      }
+    },
+    "TextageViewer.Source.ChartViewer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chart Viewer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chart Viewer"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chart Viewer"
+          }
+        }
+      }
+    },
+    "TextageViewer.Source.Legacy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legacy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レガシー"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "舊版"
           }
         }
       }

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -16,6 +16,9 @@
     "[%@](https://sdvx.in)" : {
       "shouldTranslate" : false
     },
+    "[%@](https://textage-chart-viewer.vercel.app)" : {
+      "shouldTranslate" : false
+    },
     "[%@](https://textage.cc)" : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
## Summary

Adds the [Textage Chart Viewer](https://textage-chart-viewer.vercel.app) as a second Textage source alongside the legacy textage.cc site.

### External Data Sources
- New "Textage Chart Viewer" section (listed first), with its own enable toggle, entry count, and manual **Update Data** action.
- The index is downloaded from `https://textage-chart-viewer.vercel.app/api/songs` (JSON) and stored in a new SQLite database `ExD_TextageChartViewer.db`, mirroring how the legacy Textage index works (`TextageChartViewerDatabase` / `TextageChartViewerImporter` / `IIDXReader` lookups by compact title, with `title + subtitle` concatenated for matching).

### Score viewer
- The 1P/2P (and DP) Textage buttons now show when **either** source has the chart for that difficulty; they stay hidden when neither does.
- Tapping a button opens `TextageViewer`, which now takes both URLs:
  - Both available → segmented control (Chart Viewer | Legacy) in the navigation bar, defaulting to **Chart Viewer**.
  - Only one available → no segmented control, the available source loads directly.
- Chart Viewer URLs follow `…/chart/{version}/{songId}/{difficulty}/{sp|dp}` (e.g. `/chart/27/ghosthmj/a/sp`), with difficulty codes `b/n/h/a/l` and substream using the `s` folder like the legacy site (`/chart/s/brill2u/a/sp` — verified against live URLs). The Chart Viewer has no 1P/2P distinction in its URLs (side is an on-page option), so 1P and 2P open the same Chart Viewer URL; the legacy URL still encodes the side.
- Removed the one-shot reveal guard in the web view coordinator so the page re-reveals after refresh / source switches.

### Other
- Bumped `MARKETING_VERSION` from 33.4 to 33.4.1.
- Added `en`/`ja`/`zh-Hant` strings for the new section and the source picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T2DYwivTtG2WpT4pAtv1e