### PR TITLE
Add search, filter, sort, and card editing to Sessions UI

### DIFF
--- a/DJDX/Views/Analytics/AnalyticsModel+Sessions.swift
+++ b/DJDX/Views/Analytics/AnalyticsModel+Sessions.swift
@@ -20,6 +20,7 @@ extension AnalyticsModel {
         let baseline = Self.latestPlaysPerChart(
             sessions.dropLast().flatMap { validPlays(store.plays(for: $0), playType: playType) }
         )
+        let cumulativePlays = Self.latestPlaysPerChart(baseline + lastPlays)
 
         var clearTypeTrends: [Date: [Int: OrderedDictionary<String, Int>]] = [:]
         var djLevelTrends: [Date: [Int: OrderedDictionary<String, Int>]] = [:]
@@ -36,9 +37,9 @@ extension AnalyticsModel {
         )
 
         withAnimation(.smooth.speed(2.0)) {
-            clearTypePerDifficulty = buildOrderedClearType(from: Self.clearTypeCounts(of: lastPlays))
+            clearTypePerDifficulty = buildOrderedClearType(from: Self.clearTypeCounts(of: cumulativePlays))
             djLevelPerDifficulty = convertToEnumKeyed(
-                buildOrderedDJLevel(from: Self.djLevelCounts(of: lastPlays))
+                buildOrderedDJLevel(from: Self.djLevelCounts(of: cumulativePlays))
             )
             clearTypePerImportGroup = clearTypeTrends
             djLevelPerImportGroup = djLevelTrends

--- a/DJDX/Views/Sessions/SessionScoreDataSection.swift
+++ b/DJDX/Views/Sessions/SessionScoreDataSection.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct SessionScoreDataSection: View {
+    var store: IIDXSessionStore
+    var plays: [IIDXCapturedPlay]
+    var playHistories: [String: [IIDXCapturedPlay]]
+    var songCompactTitles: [String: IIDXSong]
+    var isSearching: Bool
+    @Binding var isExpanded: Bool
+
+    @Namespace private var scoresNamespace
+
+    var body: some View {
+        VStack(spacing: 0.0) {
+            if !isSearching {
+                AnalyticsSectionHeader(
+                    title: "Analytics.Section.ScoreData",
+                    isCollapsible: true,
+                    isExpanded: isExpanded
+                ) {
+                    withAnimation(.smooth.speed(2.0)) { isExpanded.toggle() }
+                }
+                .padding(.bottom, 12.0)
+            }
+            if isExpanded || isSearching {
+                if plays.isEmpty {
+                    Text(isSearching ? "Shared.NoData" : "Sessions.Empty.Title")
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 24.0)
+                } else {
+                    Divider()
+                    ForEach(plays) { play in
+                        NavigationLink {
+                            scoreDestination(for: play)
+                        } label: {
+                            IIDXScoreRow(
+                                namespace: scoresNamespace,
+                                songRecord: play.asSongRecord(),
+                                level: play.level == .unknown ? .another : play.level,
+                                score: play.levelScore(),
+                                scoreRate: play.scoreRate(songCompactTitles: songCompactTitles)
+                            )
+                            .contentShape(.rect)
+                        }
+                        .buttonStyle(.plain)
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func scoreDestination(for play: IIDXCapturedPlay) -> some View {
+        let history = Array(playHistories[play.chartKey()]?.dropFirst() ?? [])
+        if play.hasConfidentResult {
+            CapturedPlayScoreView(store: store, play: play, history: history)
+        } else {
+            CapturedPlayDetailView(store: store, play: play)
+        }
+    }
+}

--- a/DJDX/Views/Sessions/SessionScoreFilterSheet.swift
+++ b/DJDX/Views/Sessions/SessionScoreFilterSheet.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+struct SessionScoreFilterSheet: View {
+
+    @Binding var levelsToShow: Set<IIDXLevel>
+    @Binding var difficultiesToShow: Set<IIDXDifficulty>
+    @Binding var clearTypesToShow: Set<IIDXClearType>
+    @Binding var djLevelsToShow: Set<IIDXDJLevel>
+
+    @AppStorage(wrappedValue: false, "ScoresView.BeginnerLevelHidden") var isBeginnerLevelHidden: Bool
+
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Button(.sharedFilterResetAll, systemImage: "arrow.clockwise") {
+                        levelsToShow = []
+                        difficultiesToShow = []
+                        clearTypesToShow = []
+                        djLevelsToShow = []
+                    }
+                }
+                Section(.sharedFilter) {
+                    DisclosureGroup {
+                        ForEach(IIDXLevel.sorted.filter({ !isBeginnerLevelHidden || $0 != .beginner }),
+                                id: \.self) { level in
+                            SelectableRow(
+                                isSelected: levelsToShow.contains(level)
+                            ) {
+                                Text(LocalizedStringKey(level.rawValue))
+                            } action: {
+                                if levelsToShow.contains(level) {
+                                    levelsToShow.remove(level)
+                                } else {
+                                    levelsToShow.insert(level)
+                                }
+                            }
+                        }
+                    } label: {
+                        FilterDisclosureLabel(.sharedLevel, count: levelsToShow.count,
+                                              countLabel: LocalizedStringResource("Shared.Filter.Count.Levels"))
+                    }
+                    FilterLevelDisclosure {
+                        FilterLevelGrid(
+                            items: IIDXDifficulty.sorted,
+                            selection: difficultiesToShow,
+                            title: { String($0.rawValue) },
+                            onToggle: { difficulty in
+                                if difficultiesToShow.contains(difficulty) {
+                                    difficultiesToShow.remove(difficulty)
+                                } else {
+                                    difficultiesToShow.insert(difficulty)
+                                }
+                            }
+                        )
+                    } label: {
+                        FilterDisclosureLabel(.sharedDifficulty, count: difficultiesToShow.count,
+                                              countLabel: LocalizedStringResource("Shared.Filter.Count.Difficulties"))
+                    }
+                    DisclosureGroup {
+                        ForEach(IIDXClearType.sortedWithoutNoPlay, id: \.self) { clearType in
+                            SelectableRow(
+                                isSelected: clearTypesToShow.contains(clearType)
+                            ) {
+                                Text(LocalizedStringKey(clearType.rawValue))
+                            } action: {
+                                if clearTypesToShow.contains(clearType) {
+                                    clearTypesToShow.remove(clearType)
+                                } else {
+                                    clearTypesToShow.insert(clearType)
+                                }
+                            }
+                        }
+                    } label: {
+                        FilterDisclosureLabel(
+                            LocalizedStringResource("Shared.IIDX.ClearType"),
+                            count: clearTypesToShow.count,
+                            countLabel: LocalizedStringResource("Shared.Filter.Count.ClearTypes")
+                        )
+                    }
+                    DisclosureGroup {
+                        ForEach(IIDXDJLevel.sorted.reversed(), id: \.self) { djLevel in
+                            SelectableRow(
+                                isSelected: djLevelsToShow.contains(djLevel)
+                            ) {
+                                Text(verbatim: djLevel.rawValue)
+                            } action: {
+                                if djLevelsToShow.contains(djLevel) {
+                                    djLevelsToShow.remove(djLevel)
+                                } else {
+                                    djLevelsToShow.insert(djLevel)
+                                }
+                            }
+                        }
+                    } label: {
+                        FilterDisclosureLabel(
+                            LocalizedStringResource("Shared.IIDX.DJLevel"),
+                            count: djLevelsToShow.count,
+                            countLabel: LocalizedStringResource("Shared.Filter.Count.DJLevels")
+                        )
+                    }
+                }
+            }
+            .listSectionSpacing(.compact)
+            .navigationTitle("Shared.Filter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    if #available(iOS 26.0, *) {
+                        Button(role: .confirm) {
+                            dismiss()
+                        }
+                    } else {
+                        Button(.sharedDone) {
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DJDX/Views/Sessions/SessionsHelpMenu.swift
+++ b/DJDX/Views/Sessions/SessionsHelpMenu.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct SessionsHelpMenu: View {
+    @AppStorage(wrappedValue: false, IIDXSessionWorkoutBridge.healthKitEnabledKey) private var healthKitEnabled: Bool
+
+    var body: some View {
+        Menu {
+            Text("Sessions.Welcome.Message")
+            Divider()
+            Toggle(isOn: $healthKitEnabled) {
+                Label("Sessions.HealthKit.Toggle", systemImage: "heart.fill")
+            }
+        } label: {
+            Label("Sessions.Help", systemImage: "questionmark.circle")
+        }
+        .menuOrder(.fixed)
+        .onChange(of: healthKitEnabled) { _, enabled in
+            if enabled {
+                Task { _ = await IIDXSessionWorkoutBridge.shared.requestAuthorization() }
+            }
+            IIDXSessionWorkoutBridge.shared.syncProfileToWatch()
+        }
+    }
+}

--- a/DJDX/Views/Sessions/SessionsNoticeRow.swift
+++ b/DJDX/Views/Sessions/SessionsNoticeRow.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct SessionsNoticeRow<Accessory: View>: View {
+    var systemImage: String
+    var color: Color
+    var title: LocalizedStringKey
+    var message: LocalizedStringKey
+    @ViewBuilder var accessory: () -> Accessory
+
+    init(systemImage: String,
+         color: Color,
+         title: LocalizedStringKey,
+         message: LocalizedStringKey,
+         @ViewBuilder accessory: @escaping () -> Accessory = { EmptyView() }) {
+        self.systemImage = systemImage
+        self.color = color
+        self.title = title
+        self.message = message
+        self.accessory = accessory
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12.0) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18.0, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36.0, height: 36.0)
+                .background(color, in: RoundedRectangle(cornerRadius: 9.0, style: .continuous))
+            VStack(alignment: .leading, spacing: 3.0) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                accessory()
+            }
+            Spacer(minLength: 0.0)
+        }
+        .padding(.vertical, 4.0)
+    }
+}

--- a/DJDX/Views/Sessions/SessionsView+Filtering.swift
+++ b/DJDX/Views/Sessions/SessionsView+Filtering.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+extension IIDXCapturedPlay {
+    func scoreRate(songCompactTitles: [String: IIDXSong]) -> Float? {
+        guard let title = songTitle,
+              let noteCount = songCompactTitles[title.compact]?.spNoteCount?.noteCount(for: level),
+              noteCount > 0 else { return nil }
+        return Float(exScore) / Float(noteCount * 2)
+    }
+}
+
+extension SessionsView {
+
+    var isSearching: Bool {
+        !searchTerm.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var displayedPlays: [IIDXCapturedPlay] {
+        sorted(filtered(latestPlays))
+    }
+
+    func filtered(_ plays: [IIDXCapturedPlay]) -> [IIDXCapturedPlay] {
+        let searchTermTrimmed = searchTerm.lowercased().trimmingCharacters(in: .whitespaces)
+        let difficultyRawValues = Set(difficultiesToShow.map(\.rawValue))
+        let clearTypeRawValues = Set(clearTypesToShow.map(\.rawValue))
+        let djLevelRawValues = Set(djLevelsToShow.map(\.rawValue))
+        return plays.filter { play in
+            if !searchTermTrimmed.isEmpty,
+               !(play.songTitle ?? "").lowercased().contains(searchTermTrimmed) { return false }
+            if play.level == .beginner && isBeginnerLevelHidden { return false }
+            if !levelsToShow.isEmpty && !levelsToShow.contains(play.level) { return false }
+            if !difficultiesToShow.isEmpty && !difficultyRawValues.contains(play.difficulty) { return false }
+            if !clearTypesToShow.isEmpty && !clearTypeRawValues.contains(play.clearType) { return false }
+            if !djLevelsToShow.isEmpty && !djLevelRawValues.contains(play.djLevel) { return false }
+            return true
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    func sorted(_ plays: [IIDXCapturedPlay]) -> [IIDXCapturedPlay] {
+        var plays = plays
+        let isAscending = sortOrder == .ascending
+        func title(_ play: IIDXCapturedPlay) -> String { play.songTitle ?? "" }
+
+        switch sortMode {
+        case .title:
+            plays.sort { isAscending ? title($0) < title($1) : title($0) > title($1) }
+        case .clearType:
+            let order = IIDXClearType.sortedStrings
+            plays.sort { lhs, rhs in
+                let leftIndex = order.firstIndex(of: lhs.clearType)
+                let rightIndex = order.firstIndex(of: rhs.clearType)
+                if leftIndex == rightIndex { return title(lhs) < title(rhs) }
+                guard let leftIndex, let rightIndex else { return leftIndex != nil }
+                return isAscending ? leftIndex < rightIndex : leftIndex > rightIndex
+            }
+        case .djLevel:
+            let order = IIDXDJLevel.sorted
+            plays.sort { lhs, rhs in
+                let leftIndex = order.firstIndex(of: IIDXDJLevel(rawValue: lhs.djLevel) ?? .none)
+                let rightIndex = order.firstIndex(of: IIDXDJLevel(rawValue: rhs.djLevel) ?? .none)
+                if leftIndex == rightIndex { return title(lhs) < title(rhs) }
+                guard let leftIndex, let rightIndex else { return leftIndex != nil }
+                return isAscending ? leftIndex < rightIndex : leftIndex > rightIndex
+            }
+        case .scoreRate:
+            plays.sort { lhs, rhs in
+                let leftRate = lhs.scoreRate(songCompactTitles: songCompactTitles) ?? 0.0
+                let rightRate = rhs.scoreRate(songCompactTitles: songCompactTitles) ?? 0.0
+                if leftRate == rightRate { return title(lhs) < title(rhs) }
+                return isAscending ? leftRate < rightRate : leftRate > rightRate
+            }
+        case .score:
+            plays.sort { lhs, rhs in
+                if lhs.exScore == rhs.exScore { return title(lhs) < title(rhs) }
+                return isAscending ? lhs.exScore < rhs.exScore : lhs.exScore > rhs.exScore
+            }
+        case .missCount:
+            plays.sort { lhs, rhs in
+                if lhs.miss == rhs.miss { return title(lhs) < title(rhs) }
+                return isAscending ? lhs.miss < rhs.miss : lhs.miss > rhs.miss
+            }
+        case .difficulty:
+            plays.sort { lhs, rhs in
+                if lhs.difficulty == rhs.difficulty { return title(lhs) < title(rhs) }
+                return isAscending ? lhs.difficulty < rhs.difficulty : lhs.difficulty > rhs.difficulty
+            }
+        case .lastPlayDate:
+            plays.sort { isAscending ? $0.captureDate < $1.captureDate : $0.captureDate > $1.captureDate }
+        }
+        return plays
+    }
+}

--- a/DJDX/Views/Sessions/SessionsView+Subviews.swift
+++ b/DJDX/Views/Sessions/SessionsView+Subviews.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+extension SessionsView {
+
+    @ViewBuilder var sortControl: some View {
+        IIDXScoreSortMenu(
+            sortMode: $sortMode.animation(.smooth.speed(2.0)),
+            sortOrder: $sortOrder.animation(.smooth.speed(2.0))
+        )
+    }
+
+    @ViewBuilder var filterControl: some View {
+        ScoreFilterButton(
+            isShowingFilterSheet: $isShowingFilterSheet,
+            filterNamespace: sessionsNamespace
+        )
+    }
+
+    var bemaniWikiWarning: some View {
+        SessionsNoticeRow(
+            systemImage: "exclamationmark.triangle.fill",
+            color: .orange,
+            title: "Sessions.DataSource.Warning.Title",
+            message: "Sessions.DataSource.Warning.Message"
+        ) {
+            Button("Sessions.DataSource.Warning.Action") {
+                isPresentingExternalDataSources = true
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.orange)
+            .buttonStyle(.plain)
+        }
+    }
+
+    var historySection: some View {
+        VStack(spacing: 12.0) {
+            AnalyticsSectionHeader(
+                title: "Sessions.History.Title",
+                isCollapsible: true,
+                isExpanded: isHistoryExpanded
+            ) {
+                withAnimation(.smooth.speed(2.0)) { isHistoryExpanded.toggle() }
+            }
+            if isHistoryExpanded {
+                if pastSessions.isEmpty {
+                    Text("Sessions.History.Empty.Message")
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal)
+                } else {
+                    SessionCardsRow(store: store, sessions: pastSessions)
+                }
+            }
+        }
+    }
+
+    var scoreDataSection: some View {
+        SessionScoreDataSection(
+            store: store,
+            plays: displayedPlays,
+            playHistories: playHistories,
+            songCompactTitles: songCompactTitles,
+            isSearching: isSearching,
+            isExpanded: $isScoreDataExpanded
+        )
+    }
+
+    func sessionsCard<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        let cornerRadius: CGFloat
+        if #available(iOS 26.0, *) {
+            cornerRadius = 20.0
+        } else {
+            cornerRadius = 12.0
+        }
+        return content()
+            .padding(12.0)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .cardBackground(cornerRadius: cornerRadius)
+    }
+
+    func resumeCard(_ session: IIDXPlaySession) -> some View {
+        HStack {
+            Image(systemName: "record.circle")
+                .foregroundStyle(.red)
+                .symbolEffect(.pulse)
+            VStack(alignment: .leading, spacing: 2.0) {
+                Text("Sessions.InProgress")
+                    .font(.headline)
+                Text(session.startDate, format: .dateTime.hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/DJDX/Views/Sessions/SessionsView.swift
+++ b/DJDX/Views/Sessions/SessionsView.swift
@@ -3,55 +3,82 @@ import SwiftUI
 struct SessionsView: View {
     var store: IIDXSessionStore
     var analyticsModel: AnalyticsModel
+    @Binding var isEditingAnalytics: Bool
     var analyticsNamespace: Namespace.ID
     var towerNamespace: Namespace.ID
 
-    @State private var isPresentingActive: Bool = false
-    @State private var isPresentingExternalDataSources: Bool = false
-    @State private var isHistoryExpanded: Bool = true
-    @State private var isScoreDataExpanded: Bool = true
-    @State private var latestPlays: [IIDXCapturedPlay] = []
-    @State private var playHistories: [String: [IIDXCapturedPlay]] = [:]
-    @State private var songCompactTitles: [String: IIDXSong] = [:]
-    @AppStorage(wrappedValue: false, "ExternalData.BemaniWiki2nd.Enabled") private var isBemaniWikiEnabled: Bool
-    @AppStorage(wrappedValue: true, "More.General.ShowAnalytics") private var showAnalytics: Bool
+    @State var isPresentingActive: Bool = false
+    @State var isPresentingExternalDataSources: Bool = false
+    @State var isHistoryExpanded: Bool = true
+    @State var isScoreDataExpanded: Bool = true
+    @State var latestPlays: [IIDXCapturedPlay] = []
+    @State var playHistories: [String: [IIDXCapturedPlay]] = [:]
+    @State var songCompactTitles: [String: IIDXSong] = [:]
+    @State var searchTerm: String = ""
+    @State var isShowingFilterSheet: Bool = false
+    @AppStorage(wrappedValue: false, "ExternalData.BemaniWiki2nd.Enabled") var isBemaniWikiEnabled: Bool
+    @AppStorage(wrappedValue: true, "More.General.ShowAnalytics") var showAnalytics: Bool
+    @AppStorage(wrappedValue: false, "ScoresView.BeginnerLevelHidden") var isBeginnerLevelHidden: Bool
+
+    @AppStorage(wrappedValue: [], "SessionsView.LevelFilters") var levelsToShow: Set<IIDXLevel>
+    @AppStorage(wrappedValue: [], "SessionsView.DifficultyFilters") var difficultiesToShow: Set<IIDXDifficulty>
+    @AppStorage(wrappedValue: [], "SessionsView.ClearTypeFilters") var clearTypesToShow: Set<IIDXClearType>
+    @AppStorage(wrappedValue: [], "SessionsView.DJLevelFilters") var djLevelsToShow: Set<IIDXDJLevel>
+    @AppStorage(wrappedValue: .lastPlayDate, "SessionsView.SortOrder") var sortMode: SortMode
+    @AppStorage(wrappedValue: .descending, "SessionsView.SortDirection") var sortOrder: SortOrder
+
+    @Namespace var sessionsNamespace
 
     private let reader = IIDXReader()
 
-    private var pastSessions: [IIDXPlaySession] {
+    var pastSessions: [IIDXPlaySession] {
         store.sessions.filter { !$0.isActive }.sorted { $0.startDate > $1.startDate }
+    }
+
+    var searchPlacement: SearchFieldPlacement {
+        if #available(iOS 26.0, *) {
+            .automatic
+        } else {
+            .navigationBarDrawer(displayMode: .always)
+        }
     }
 
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0.0) {
-                if !isBemaniWikiEnabled || store.activeSession != nil {
-                    VStack(spacing: 12.0) {
-                        if !isBemaniWikiEnabled {
-                            sessionsCard { bemaniWikiWarning }
-                        }
-                        if let active = store.activeSession {
-                            Button {
-                                isPresentingActive = true
-                            } label: {
-                                sessionsCard { resumeCard(active) }
+                if !isSearching {
+                    if !isEditingAnalytics, !isBemaniWikiEnabled || store.activeSession != nil {
+                        VStack(spacing: 12.0) {
+                            if !isBemaniWikiEnabled {
+                                sessionsCard { bemaniWikiWarning }
                             }
-                            .buttonStyle(.plain)
+                            if let active = store.activeSession {
+                                Button {
+                                    isPresentingActive = true
+                                } label: {
+                                    sessionsCard { resumeCard(active) }
+                                }
+                                .buttonStyle(.plain)
+                            }
                         }
+                        .padding(.horizontal)
+                        .padding(.top, 8.0)
                     }
-                    .padding(.horizontal)
-                    .padding(.top, 8.0)
+                    if !isEditingAnalytics {
+                        historySection
+                            .padding(.top, 20.0)
+                    }
+                    if showAnalytics {
+                        AnalyticsView(model: analyticsModel,
+                                      isEditing: $isEditingAnalytics,
+                                      analyticsNamespace: analyticsNamespace,
+                                      towerNamespace: towerNamespace)
+                    }
                 }
-                historySection
-                    .padding(.top, 20.0)
-                if showAnalytics {
-                    AnalyticsView(model: analyticsModel,
-                                  isEditing: .constant(false),
-                                  analyticsNamespace: analyticsNamespace,
-                                  towerNamespace: towerNamespace)
+                if !isEditingAnalytics {
+                    scoreDataSection
+                        .padding(.top, isSearching ? 8.0 : 20.0)
                 }
-                scoreDataSection
-                    .padding(.top, 20.0)
             }
             .padding(.bottom, 8.0)
         }
@@ -62,6 +89,41 @@ struct SessionsView: View {
                 endPoint: .bottom
             )
             .ignoresSafeArea()
+        }
+        .searchable(text: $searchTerm,
+                    placement: searchPlacement,
+                    prompt: "Scores.Search.Prompt")
+        .toolbar {
+            if #available(iOS 26.0, *) {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    SessionsHelpMenu()
+                }
+                ToolbarSpacer(.fixed, placement: .bottomBar)
+                DefaultToolbarItem(kind: .search, placement: .bottomBar)
+                ToolbarSpacer(.fixed, placement: .bottomBar)
+                ToolbarItemGroup(placement: .bottomBar) {
+                    sortControl
+                    filterControl
+                }
+            } else {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    SessionsHelpMenu()
+                    Spacer()
+                    sortControl
+                    filterControl
+                }
+            }
+        }
+        .sheet(isPresented: $isShowingFilterSheet) {
+            SessionScoreFilterSheet(
+                levelsToShow: $levelsToShow.animation(.smooth.speed(2.0)),
+                difficultiesToShow: $difficultiesToShow.animation(.smooth.speed(2.0)),
+                clearTypesToShow: $clearTypesToShow.animation(.smooth.speed(2.0)),
+                djLevelsToShow: $djLevelsToShow.animation(.smooth.speed(2.0))
+            )
+            .automaticSheetNavigationTransition(id: "ScoreFilterSheet", in: sessionsNamespace)
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.hidden)
         }
         .onAppear {
             store.bootstrap()
@@ -96,67 +158,6 @@ struct SessionsView: View {
         }
     }
 
-    private var bemaniWikiWarning: some View {
-        SessionsNoticeRow(
-            systemImage: "exclamationmark.triangle.fill",
-            color: .orange,
-            title: "Sessions.DataSource.Warning.Title",
-            message: "Sessions.DataSource.Warning.Message"
-        ) {
-            Button("Sessions.DataSource.Warning.Action") {
-                isPresentingExternalDataSources = true
-            }
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(.orange)
-            .buttonStyle(.plain)
-        }
-    }
-
-    private var historySection: some View {
-        VStack(spacing: 12.0) {
-            AnalyticsSectionHeader(
-                title: "Sessions.History.Title",
-                isCollapsible: true,
-                isExpanded: isHistoryExpanded
-            ) {
-                withAnimation(.smooth.speed(2.0)) { isHistoryExpanded.toggle() }
-            }
-            if isHistoryExpanded {
-                if pastSessions.isEmpty {
-                    Text("Sessions.History.Empty.Message")
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
-                } else {
-                    SessionCardsRow(store: store, sessions: pastSessions)
-                }
-            }
-        }
-    }
-
-    private var scoreDataSection: some View {
-        SessionScoreDataSection(
-            store: store,
-            latestPlays: latestPlays,
-            playHistories: playHistories,
-            songCompactTitles: songCompactTitles,
-            isExpanded: $isScoreDataExpanded
-        )
-    }
-
-    private func sessionsCard<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        let cornerRadius: CGFloat
-        if #available(iOS 26.0, *) {
-            cornerRadius = 20.0
-        } else {
-            cornerRadius = 12.0
-        }
-        return content()
-            .padding(12.0)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .cardBackground(cornerRadius: cornerRadius)
-    }
-
     private func reloadScores() {
         var allPlays: [IIDXCapturedPlay] = []
         for session in store.sessions {
@@ -177,154 +178,5 @@ struct SessionsView: View {
         }
         playHistories = histories
         latestPlays = histories.values.compactMap(\.first).sorted { $0.captureDate > $1.captureDate }
-    }
-
-    private func resumeCard(_ session: IIDXPlaySession) -> some View {
-        HStack {
-            Image(systemName: "record.circle")
-                .foregroundStyle(.red)
-                .symbolEffect(.pulse)
-            VStack(alignment: .leading, spacing: 2.0) {
-                Text("Sessions.InProgress")
-                    .font(.headline)
-                Text(session.startDate, format: .dateTime.hour().minute())
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.caption.bold())
-                .foregroundStyle(.tertiary)
-        }
-    }
-}
-
-struct SessionScoreDataSection: View {
-    var store: IIDXSessionStore
-    var latestPlays: [IIDXCapturedPlay]
-    var playHistories: [String: [IIDXCapturedPlay]]
-    var songCompactTitles: [String: IIDXSong]
-    @Binding var isExpanded: Bool
-
-    @Namespace private var scoresNamespace
-
-    var body: some View {
-        VStack(spacing: 0.0) {
-            AnalyticsSectionHeader(
-                title: "Analytics.Section.ScoreData",
-                isCollapsible: true,
-                isExpanded: isExpanded
-            ) {
-                withAnimation(.smooth.speed(2.0)) { isExpanded.toggle() }
-            }
-            .padding(.bottom, 12.0)
-            if isExpanded {
-                if latestPlays.isEmpty {
-                    Text("Sessions.Empty.Title")
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 24.0)
-                } else {
-                    Divider()
-                    ForEach(latestPlays) { play in
-                        NavigationLink {
-                            scoreDestination(for: play)
-                        } label: {
-                            IIDXScoreRow(
-                                namespace: scoresNamespace,
-                                songRecord: play.asSongRecord(),
-                                level: play.level == .unknown ? .another : play.level,
-                                score: play.levelScore(),
-                                scoreRate: scoreRate(for: play)
-                            )
-                            .contentShape(.rect)
-                        }
-                        .buttonStyle(.plain)
-                        Divider()
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func scoreDestination(for play: IIDXCapturedPlay) -> some View {
-        let history = Array(playHistories[play.chartKey()]?.dropFirst() ?? [])
-        if play.hasConfidentResult {
-            CapturedPlayScoreView(store: store, play: play, history: history)
-        } else {
-            CapturedPlayDetailView(store: store, play: play)
-        }
-    }
-
-    private func scoreRate(for play: IIDXCapturedPlay) -> Float? {
-        guard let title = play.songTitle,
-              let noteCount = songCompactTitles[title.compact]?.spNoteCount?.noteCount(for: play.level),
-              noteCount > 0 else { return nil }
-        return Float(play.exScore) / Float(noteCount * 2)
-    }
-}
-
-struct SessionsNoticeRow<Accessory: View>: View {
-    var systemImage: String
-    var color: Color
-    var title: LocalizedStringKey
-    var message: LocalizedStringKey
-    @ViewBuilder var accessory: () -> Accessory
-
-    init(systemImage: String,
-         color: Color,
-         title: LocalizedStringKey,
-         message: LocalizedStringKey,
-         @ViewBuilder accessory: @escaping () -> Accessory = { EmptyView() }) {
-        self.systemImage = systemImage
-        self.color = color
-        self.title = title
-        self.message = message
-        self.accessory = accessory
-    }
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12.0) {
-            Image(systemName: systemImage)
-                .font(.system(size: 18.0, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 36.0, height: 36.0)
-                .background(color, in: RoundedRectangle(cornerRadius: 9.0, style: .continuous))
-            VStack(alignment: .leading, spacing: 3.0) {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                Text(message)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                accessory()
-            }
-            Spacer(minLength: 0.0)
-        }
-        .padding(.vertical, 4.0)
-    }
-}
-
-struct SessionsHelpMenu: View {
-    @AppStorage(wrappedValue: false, IIDXSessionWorkoutBridge.healthKitEnabledKey) private var healthKitEnabled: Bool
-
-    var body: some View {
-        Menu {
-            Text("Sessions.Welcome.Message")
-            Divider()
-            Toggle(isOn: $healthKitEnabled) {
-                Label("Sessions.HealthKit.Toggle", systemImage: "heart.fill")
-            }
-        } label: {
-            Label("Sessions.Help", systemImage: "questionmark.circle")
-        }
-        .menuOrder(.fixed)
-        .onChange(of: healthKitEnabled) { _, enabled in
-            if enabled {
-                Task { _ = await IIDXSessionWorkoutBridge.shared.requestAuthorization() }
-            }
-            IIDXSessionWorkoutBridge.shared.syncProfileToWatch()
-        }
     }
 }

--- a/DJDX/Views/UnifiedView+Toolbar.swift
+++ b/DJDX/Views/UnifiedView+Toolbar.swift
@@ -3,6 +3,31 @@ import SwiftUI
 extension UnifiedView {
 
     @ViewBuilder
+    var sessionButton: some View {
+        let isActive = sessionStore.activeSession != nil
+        let button = Button {
+            if isActive {
+                sessionStore.endSession()
+            } else {
+                sessionStore.startSession()
+            }
+        } label: {
+            if isActive {
+                Label("Sessions.End", systemImage: "stop.fill")
+            } else {
+                Label("Sessions.Start", systemImage: "play.fill")
+            }
+        }
+        .tint(isActive ? .red : .accent)
+
+        if #available(iOS 26.0, *) {
+            button.buttonStyle(.glassProminent)
+        } else {
+            button.buttonStyle(.borderedProminent)
+        }
+    }
+
+    @ViewBuilder
     var gameMenu: some View {
         Menu {
             Section {

--- a/DJDX/Views/UnifiedView.swift
+++ b/DJDX/Views/UnifiedView.swift
@@ -71,6 +71,7 @@ struct UnifiedView: View {
                 if isSessionsMode {
                     SessionsView(store: sessionStore,
                                  analyticsModel: sessionAnalyticsModel,
+                                 isEditingAnalytics: $isEditingAnalytics,
                                  analyticsNamespace: analyticsNamespace,
                                  towerNamespace: towerNamespace)
                 } else if selectedGame == .soundVoltex {
@@ -113,7 +114,9 @@ struct UnifiedView: View {
                     ToolbarSpacer(.fixed, placement: .topBarLeading)
                 }
                 ToolbarItemGroup(placement: .topBarLeading) {
-                    if !isSessionsMode {
+                    if isSessionsMode {
+                        sessionButton
+                    } else {
                         Button("Shared.Import", systemImage: "arrow.down.circle.dotted") {
                             isPresentingImport = true
                         }
@@ -121,7 +124,7 @@ struct UnifiedView: View {
                         .automaticSheetMatchedTransitionSource(id: "Import", in: importNamespace)
                     }
                 }
-                if !isSessionsMode {
+                if !isSessionsMode || showAnalytics {
                     ToolbarItemGroup(placement: .topBarTrailing) {
                         Button {
                             withAnimation(.smooth.speed(2.0)) { isEditingAnalytics.toggle() }
@@ -139,30 +142,6 @@ struct UnifiedView: View {
                 }
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     MoreMenu()
-                }
-                if isSessionsMode {
-                    ToolbarItemGroup(placement: .bottomBar) {
-                        Spacer()
-                        Button {
-                            if sessionStore.activeSession == nil {
-                                sessionStore.startSession()
-                            } else {
-                                sessionStore.endSession()
-                            }
-                        } label: {
-                            if sessionStore.activeSession == nil {
-                                Label("Sessions.Start", systemImage: "play.fill")
-                            } else {
-                                Label("Sessions.End", systemImage: "stop.fill")
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .labelsVisibility(.visible)
-                        .labelStyle(.titleAndIcon)
-                        .tint(sessionStore.activeSession == nil ? .accent : .red)
-                        Spacer()
-                        SessionsHelpMenu()
-                    }
                 }
             }
             .navigationDestination(for: MorePath.self) { viewPath in
@@ -254,6 +233,9 @@ struct UnifiedView: View {
             if !newValue.supportsSessions {
                 appMode = .imports
             }
+        }
+        .onChange(of: appMode) { _, _ in
+            isEditingAnalytics = false
         }
         .onReceive(NotificationCenter.default.publisher(for: .startSessionRequested)
             .receive(on: RunLoop.main)) { notification in

--- a/DJDX/Views/beatmania IIDX/Scores/IIDXScoreSortMenu.swift
+++ b/DJDX/Views/beatmania IIDX/Scores/IIDXScoreSortMenu.swift
@@ -218,7 +218,7 @@ struct ScoreFilterSheet: View {
     }
 }
 
-private struct FilterDisclosureLabel: View {
+struct FilterDisclosureLabel: View {
 
     let title: LocalizedStringResource
     let count: Int
@@ -245,7 +245,7 @@ private struct FilterDisclosureLabel: View {
     }
 }
 
-private struct SelectableRow<Label: View>: View {
+struct SelectableRow<Label: View>: View {
 
     var isSelected: Bool
     @ViewBuilder var label: Label

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -6520,19 +6520,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Start a session while you play, then snap result screens with your camera to log your scores. Scores are read using machine learning, so be sure to verify the results."
+            "value" : "Snap result screens to log your scores. Always check the results."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "プレー中にセッションを開始し、カメラでリザルト画面を撮影するとスコアを記録できます。スコアの読み取りには機械学習を使用しているため、結果を必ず確認してください。"
+            "value" : "リザルト画面を撮影してスコアを記録します。結果は必ず確認してください。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "遊玩時開始一段遊玩記錄，再用相機拍攝結果畫面，即可記錄分數。由於分數是透過機器學習讀取的，請務必確認結果是否正確。"
+            "value" : "拍攝結果畫面即可記錄分數。請務必確認結果。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add search, filter (level/difficulty/clear type/DJ level), and sort to the Sessions score list, reusing the same controls and sheet pattern as Play Data mode
- Enable analytics card editing in Sessions mode via a real `isEditingAnalytics` binding
- Move the start/end session button to the top leading toolbar, next to the mode switcher, in the same slot Import occupies in Play Data mode
- Shorten the sessions help menu message (en/ja/zh-Hant) so it no longer truncates in the popover

## Test plan
- [x] `xcodebuild build` succeeds, SwiftLint clean (aside from two pre-existing warnings unrelated to this change)
- [x] Verified in iOS Simulator: sort order (title/ascending) reorders the score list correctly
- [x] Verified in iOS Simulator: difficulty filter narrows the score list to matching entries
- [ ] Manual verification of filter sheet presentation and analytics card drag-reorder in Sessions mode (not exercised — simulator in this session was headless/non-interactive)